### PR TITLE
Ensure the desired namespace is used

### DIFF
--- a/shopping-cart/deploy/scripts/common/deployment-tools.sh
+++ b/shopping-cart/deploy/scripts/common/deployment-tools.sh
@@ -8,6 +8,11 @@ deleteNamespace() {
     oc delete project $NAMESPACE
 }
 
+useNamespace() {
+    NAMESPACE=$1
+    oc project $NAMESPACE
+}
+
 ## Creates a namespace. This operation will timeout in 20 seconds.
 ##
 ## 1. NAMESPACE

--- a/shopping-cart/deploy/scripts/deploy-shopping-cart.sh
+++ b/shopping-cart/deploy/scripts/deploy-shopping-cart.sh
@@ -40,6 +40,7 @@ echo "Deploying to $NAMESPACE"
 # 3. Recreate the NAMESPACE
 deleteNamespace $NAMESPACE
 createNamespace $NAMESPACE
+useNamespace $NAMESPACE
 
 # 4. Install PG and create a DB and a schema
 . $COMMON_SCRIPTS_DIR/postgresql.sh

--- a/shopping-cart/deploy/scripts/test-shopping-cart.sh
+++ b/shopping-cart/deploy/scripts/test-shopping-cart.sh
@@ -31,7 +31,7 @@ echo "Testing deployment $NAMESPACE"
 
 # 2. Load extra tools to manage the deployment
 . $COMMON_SCRIPTS_DIR/deployment-tools.sh
-
+useNamespace $NAMESPACE
 
 SHOPPING_CART_HOST=$(oc get route shopping-cart -o jsonpath='{.spec.host}')
 INVENTORY_HOST=$(oc get route inventory -o jsonpath='{.spec.host}')


### PR DESCRIPTION
The current deployment scripts work by coincidence assuming that a newly created namespace is immediately used.
This change ensure the created namespace is then chosen for usage.