### PR TITLE
Update grpc testkit

### DIFF
--- a/grpc-example/grpc-example-java/build.sbt
+++ b/grpc-example/grpc-example-java/build.sbt
@@ -12,7 +12,7 @@ scalaVersion in ThisBuild := "2.12.8"
 lagomServiceEnableSsl in ThisBuild := true
 val `hello-impl-HTTPS-port` = 11000
 
-val lagomGrpcTestkit = "com.lightbend.play" %% "lagom-javadsl-grpc-testkit" % "0.6.0"
+val lagomGrpcTestkit = "com.lightbend.play" %% "lagom-javadsl-grpc-testkit" % "0.7.0" % Test
 
 lazy val `lagom-java-grpc-example` = (project in file("."))
   .aggregate(`hello-api`, `hello-impl`, `hello-proxy-api`, `hello-proxy-impl`)

--- a/grpc-example/grpc-example-scala/build.sbt
+++ b/grpc-example/grpc-example-scala/build.sbt
@@ -9,7 +9,7 @@ scalaVersion in ThisBuild := "2.12.8"
 val macwire = "com.softwaremill.macwire" %% "macros" % "2.3.0" % "provided"
 val scalaTest = "org.scalatest" %% "scalatest" % "3.0.4" % Test
 
-val lagomGrpcTestkit = "com.lightbend.play" %% "lagom-scaladsl-grpc-testkit" % "0.6.0"
+val lagomGrpcTestkit = "com.lightbend.play" %% "lagom-scaladsl-grpc-testkit" % "0.7.0" % Test
 
 lagomServiceEnableSsl in ThisBuild := true
 val `hello-impl-HTTPS-port` = 11000


### PR DESCRIPTION
This PR bumps the testkit to 0.7.0 and adds it to 'Test' scope.

In case of the Java sample, the fact that it was not in 'Test' scope causes the application to fail. 
Guice tries to find the persistence registry to write, but there is none. 

(also unclear why testkit is bringing in persistence, but that's another story)