### PR TITLE
Adds a read-side processor to shopping-cart Scala

### DIFF
--- a/shopping-cart/shopping-cart-scala/shopping-cart-api/src/main/scala/com/example/shoppingcart/api/ShoppingCartService.scala
+++ b/shopping-cart/shopping-cart-scala/shopping-cart-api/src/main/scala/com/example/shoppingcart/api/ShoppingCartService.scala
@@ -1,5 +1,7 @@
 package com.example.shoppingcart.api
 
+import java.time.Instant
+
 import akka.{Done, NotUsed}
 import com.lightbend.lagom.scaladsl.api.broker.Topic
 import com.lightbend.lagom.scaladsl.api.broker.kafka.{KafkaProperties, PartitionKeyStrategy}
@@ -27,6 +29,13 @@ trait ShoppingCartService extends Service {
   def get(id: String): ServiceCall[NotUsed, ShoppingCart]
 
   /**
+   * Get a shopping cart report (view model).
+   *
+   * Example: curl http://localhost:9000/shoppingcart/123/report
+   */
+  def getReport(id: String): ServiceCall[NotUsed, ShoppingCartReport]
+
+  /**
     * Update an items quantity in the shopping cart.
     *
     * Example: curl -H "Content-Type: application/json" -X POST -d '{"productId": 456, "quantity": 2}' http://localhost:9000/shoppingcart/123
@@ -51,6 +60,7 @@ trait ShoppingCartService extends Service {
     named("shopping-cart")
       .withCalls(
         restCall(Method.GET, "/shoppingcart/:id", get _),
+        restCall(Method.GET, "/shoppingcart/:id/report", getReport _),
         restCall(Method.POST, "/shoppingcart/:id", updateItem _),
         restCall(Method.POST, "/shoppingcart/:id/checkout", checkout _)
       )
@@ -101,3 +111,16 @@ object ShoppingCart {
 
   implicit val format: Format[ShoppingCart] = Json.format
 }
+
+
+/**
+ * A shopping cart report exposes information about a ShoppingCart.
+ */
+case class ShoppingCartReport(cartId: String,
+                              creationDate: Instant,
+                              checkoutDate: Option[Instant])
+
+object ShoppingCartReport {
+  implicit val format: Format[ShoppingCartReport] = Json.format
+}
+

--- a/shopping-cart/shopping-cart-scala/shopping-cart/src/main/scala/com/example/shoppingcart/impl/ShoppingCartLoader.scala
+++ b/shopping-cart/shopping-cart-scala/shopping-cart/src/main/scala/com/example/shoppingcart/impl/ShoppingCartLoader.scala
@@ -4,7 +4,7 @@ import com.example.shoppingcart.api.ShoppingCartService
 import com.lightbend.lagom.scaladsl.akka.discovery.AkkaDiscoveryComponents
 import com.lightbend.lagom.scaladsl.broker.kafka.LagomKafkaComponents
 import com.lightbend.lagom.scaladsl.devmode.LagomDevModeComponents
-import com.lightbend.lagom.scaladsl.persistence.jdbc.JdbcPersistenceComponents
+import com.lightbend.lagom.scaladsl.persistence.slick.SlickPersistenceComponents
 import com.lightbend.lagom.scaladsl.server._
 import com.softwaremill.macwire._
 import play.api.db.HikariCPComponents
@@ -23,7 +23,7 @@ class ShoppingCartLoader extends LagomApplicationLoader {
 
 abstract class ShoppingCartApplication(context: LagomApplicationContext)
   extends LagomApplication(context)
-    with JdbcPersistenceComponents
+    with SlickPersistenceComponents
     with HikariCPComponents
     with LagomKafkaComponents
     with AhcWSComponents {
@@ -36,4 +36,8 @@ abstract class ShoppingCartApplication(context: LagomApplicationContext)
 
   // Register the ShoppingCart persistent entity
   persistentEntityRegistry.register(wire[ShoppingCartEntity])
+
+  lazy val reportRepository = wire[ShoppingCartReportRepository]
+
+  readSide.register(wire[ShoppingCartReportProcessor])
 }

--- a/shopping-cart/shopping-cart-scala/shopping-cart/src/main/scala/com/example/shoppingcart/impl/ShoppingCartReportProcessor.scala
+++ b/shopping-cart/shopping-cart-scala/shopping-cart/src/main/scala/com/example/shoppingcart/impl/ShoppingCartReportProcessor.scala
@@ -1,0 +1,23 @@
+package com.example.shoppingcart.impl
+
+import com.lightbend.lagom.scaladsl.persistence.ReadSideProcessor
+import com.lightbend.lagom.scaladsl.persistence.slick.SlickReadSide
+
+
+class ShoppingCartReportProcessor(readSide: SlickReadSide,
+                                  repository: ShoppingCartReportRepository) extends ReadSideProcessor[ShoppingCartEvent] {
+
+  override def buildHandler() =
+    readSide
+      .builder[ShoppingCartEvent]("shopping-cart-view")
+      .setGlobalPrepare(repository.createTable())
+      .setEventHandler[ItemUpdated] { envelope =>
+        repository.createReport(envelope.entityId, envelope.event.eventTime)
+      }
+      .setEventHandler[CheckedOut] { envelope =>
+        repository.addCheckoutTime(envelope.entityId, envelope.event.eventTime)
+      }
+      .build()
+
+  override def aggregateTags = Set(ShoppingCartEvent.Tag)
+}

--- a/shopping-cart/shopping-cart-scala/shopping-cart/src/main/scala/com/example/shoppingcart/impl/ShoppingCartReportRepository.scala
+++ b/shopping-cart/shopping-cart-scala/shopping-cart/src/main/scala/com/example/shoppingcart/impl/ShoppingCartReportRepository.scala
@@ -1,0 +1,58 @@
+package com.example.shoppingcart.impl
+
+import java.time.Instant
+
+import akka.Done
+import com.example.shoppingcart.api.ShoppingCartReport
+import slick.dbio.DBIO
+import slick.jdbc.PostgresProfile.api._
+
+import scala.concurrent.ExecutionContext.Implicits.global
+import scala.concurrent.Future
+
+/**
+ * The report repository manage the storage of ShoppingCartReport which is a API class (view model).
+ *
+ * It saves data in a ready for consumption format for that specific API model.
+ * If the API changes, we must regenerated the stored models.
+ */
+class ShoppingCartReportRepository(database: Database) {
+
+  class ShoppingCartReportTable(tag: Tag) extends Table[ShoppingCartReport](tag, "shopping_cart_report") {
+    def cartId = column[String]("cart_id", O.PrimaryKey)
+
+    def creationDate = column[Instant]("creation_date")
+
+    def checkoutDate = column[Option[Instant]]("checkout_date")
+
+    def * = (cartId, creationDate, checkoutDate) <> ((ShoppingCartReport.apply _).tupled, ShoppingCartReport.unapply)
+  }
+
+  val reportTable = TableQuery[ShoppingCartReportTable]
+
+  def createTable() = reportTable.schema.createIfNotExists
+
+  def findById(id: String): Future[Option[ShoppingCartReport]] =
+    database.run(findByIdQuery(id))
+
+  def createReport(cartId: String, creationDate: Instant): DBIO[Done] = {
+    findByIdQuery(cartId).flatMap {
+      case None => reportTable += ShoppingCartReport(cartId, creationDate, None)
+      case _ => DBIO.successful(Done)
+    }.map(_ => Done).transactionally
+  }
+
+  def addCheckoutTime(cartId: String, checkoutDate: Instant): DBIO[Done] = {
+    findByIdQuery(cartId).flatMap {
+      case Some(cart) => reportTable.insertOrUpdate(cart.copy(checkoutDate = Some(checkoutDate)))
+      // if that happens we have a corrupted system
+      // cart checkout can only happens for a existing cart
+      case None => throw new RuntimeException(s"Didn't find cart for checkout. CartID: $cartId")
+    }.map(_ => Done).transactionally
+  }
+
+  private def findByIdQuery(cartId: String): DBIO[Option[ShoppingCartReport]] =
+    reportTable
+      .filter(_.cartId === cartId)
+      .result.headOption
+}

--- a/shopping-cart/shopping-cart-scala/shopping-cart/src/main/scala/com/example/shoppingcart/impl/ShoppingCartServiceImpl.scala
+++ b/shopping-cart/shopping-cart-scala/shopping-cart/src/main/scala/com/example/shoppingcart/impl/ShoppingCartServiceImpl.scala
@@ -1,10 +1,12 @@
 package com.example.shoppingcart.impl
 
+import java.time.OffsetDateTime
+
 import akka.{Done, NotUsed}
-import com.example.shoppingcart.api.{ShoppingCart, ShoppingCartItem, ShoppingCartService}
+import com.example.shoppingcart.api.{ShoppingCart, ShoppingCartItem, ShoppingCartReport, ShoppingCartService}
 import com.lightbend.lagom.scaladsl.api.ServiceCall
 import com.lightbend.lagom.scaladsl.api.broker.Topic
-import com.lightbend.lagom.scaladsl.api.transport.BadRequest
+import com.lightbend.lagom.scaladsl.api.transport.{BadRequest, NotFound, TransportException}
 import com.lightbend.lagom.scaladsl.broker.TopicProducer
 import com.lightbend.lagom.scaladsl.persistence.{EventStreamElement, PersistentEntityRegistry}
 
@@ -13,7 +15,7 @@ import scala.concurrent.ExecutionContext
 /**
   * Implementation of the `ShoppingCartService`.
   */
-class ShoppingCartServiceImpl(persistentEntityRegistry: PersistentEntityRegistry)(implicit ec: ExecutionContext) extends ShoppingCartService {
+class ShoppingCartServiceImpl(persistentEntityRegistry: PersistentEntityRegistry, reportRepository: ShoppingCartReportRepository)(implicit ec: ExecutionContext) extends ShoppingCartService {
 
   /**
     * Looks up the shopping cart entity for the given ID.
@@ -45,7 +47,7 @@ class ShoppingCartServiceImpl(persistentEntityRegistry: PersistentEntityRegistry
 
   override def shoppingCartTopic: Topic[ShoppingCart] = TopicProducer.singleStreamWithOffset { fromOffset =>
     persistentEntityRegistry.eventStream(ShoppingCartEvent.Tag, fromOffset)
-      .filter(_.event.isInstanceOf[CheckedOut.type])
+      .filter(_.event.isInstanceOf[CheckedOut])
       .mapAsync(4) {
         case EventStreamElement(id, _, offset) =>
           entityRef(id)
@@ -56,5 +58,12 @@ class ShoppingCartServiceImpl(persistentEntityRegistry: PersistentEntityRegistry
 
   private def convertShoppingCart(id: String, cart: ShoppingCartState) = {
     ShoppingCart(id, cart.items.map((ShoppingCartItem.apply _).tupled).toSeq, cart.checkedOut)
+  }
+
+  override def getReport(cartId: String): ServiceCall[NotUsed, ShoppingCartReport] = ServiceCall { _ =>
+    reportRepository.findById(cartId).map {
+      case Some(cart) => cart
+      case None => throw NotFound(s"Couldn't find a shopping cart report for $cartId")
+    }
   }
 }

--- a/shopping-cart/shopping-cart-scala/shopping-cart/src/test/scala/com/example/shoppingcart/impl/ShoppingCartReportSpec.scala
+++ b/shopping-cart/shopping-cart-scala/shopping-cart/src/test/scala/com/example/shoppingcart/impl/ShoppingCartReportSpec.scala
@@ -1,0 +1,115 @@
+package com.example.shoppingcart.impl
+
+import java.time.Instant
+import java.util.UUID
+import java.util.concurrent.atomic.AtomicInteger
+
+import akka.Done
+import akka.persistence.query.Sequence
+import com.lightbend.lagom.scaladsl.api.ServiceLocator.NoServiceLocator
+import com.lightbend.lagom.scaladsl.testkit.{ReadSideTestDriver, ServiceTest}
+import org.scalatest._
+import org.scalatest.concurrent.ScalaFutures
+
+import scala.concurrent.Future
+
+class ShoppingCartReportSpec extends WordSpec with BeforeAndAfterAll with Matchers with ScalaFutures with OptionValues {
+
+  private val server = ServiceTest.startServer(ServiceTest.defaultSetup.withJdbc(true)) { ctx =>
+    new ShoppingCartApplication(ctx) {
+      override def serviceLocator = NoServiceLocator
+      override lazy val readSide: ReadSideTestDriver = new ReadSideTestDriver
+    }
+  }
+
+  override def afterAll() = server.stop()
+
+  private val testDriver = server.application.readSide
+  private val reportRepository = server.application.reportRepository
+  private val offset = new AtomicInteger()
+  private implicit val  exeCxt = server.actorSystem.dispatcher
+
+  "The shopping cart report processor" should {
+
+    "create a report on first event" in {
+      val cartId = UUID.randomUUID().toString
+
+      withClue("Cart report is not expected to exist") {
+        reportRepository.findById(cartId).futureValue shouldBe None
+      }
+
+      val eventTime = Instant.now()
+
+      val updatedReport =
+        for {
+          _ <- feedEvent(cartId, ItemUpdated("test1", 1, eventTime))
+          report <- reportRepository.findById(cartId)
+        } yield report
+
+      withClue("Cart report is created on first event") {
+        whenReady(updatedReport) { result =>
+          val report = result.value
+          report.creationDate shouldBe eventTime
+          report.checkoutDate shouldBe None
+        }
+      }
+    }
+
+    "NOT update a report on subsequent ItemUpdated events" in {
+      val cartId = UUID.randomUUID().toString
+
+      withClue("Cart report is not expected to exist") {
+        reportRepository.findById(cartId).futureValue shouldBe None
+      }
+
+      val eventTime = Instant.now()
+
+      val updatedReport =
+        for {
+          _ <- feedEvent(cartId, ItemUpdated("test2", 1, eventTime))
+          _ <- feedEvent(cartId, ItemUpdated("test2", 2, eventTime.plusSeconds(5)))
+          _ <- feedEvent(cartId, ItemUpdated("test2", 3, eventTime.plusSeconds(10)))
+          report <- reportRepository.findById(cartId)
+        } yield report
+
+      withClue("Cart report's creationDate should not change") {
+        whenReady(updatedReport) { result =>
+          val report = result.value
+          report.creationDate shouldBe eventTime
+          report.checkoutDate shouldBe None
+        }
+      }
+    }
+
+    "produce a checked-out report on check-out event" in {
+      val cartId = UUID.randomUUID().toString
+
+      withClue("Cart report is not expected to exist") {
+        reportRepository.findById(cartId).futureValue shouldBe None
+      }
+
+      val eventTime = Instant.now()
+      val checkedOutTime = eventTime.plusSeconds(30)
+
+      val updatedReport =
+        for {
+          _ <- feedEvent(cartId, ItemUpdated("test3", 1, eventTime))
+          _ <- feedEvent(cartId, CheckedOut(checkedOutTime))
+          report <- reportRepository.findById(cartId)
+        } yield report
+
+      withClue("Cart report is marked as checked-out") {
+        whenReady(updatedReport) { result =>
+          val report = result.value
+          report.creationDate shouldBe eventTime
+          report.checkoutDate shouldBe Some(checkedOutTime)
+        }
+      }
+    }
+
+  }
+
+  private def feedEvent(cartId: String, event: ShoppingCartEvent): Future[Done] = {
+    testDriver.feed(cartId, event, Sequence(offset.getAndIncrement))
+  }
+}


### PR DESCRIPTION
The processor listen to shopping carts events and generates a report.
The report contains the cart's creation date and checkout, nothing more.

Events got updated to have a event date that is used to generated the report.