### PR TITLE
Add Maven instructions for Java Shopping Cart

### DIFF
--- a/shopping-cart/shopping-cart-java/README.md
+++ b/shopping-cart/shopping-cart-java/README.md
@@ -32,6 +32,12 @@ Once PostgreSQL is setup, you can start the system by running:
 sbt runAll
 ```
 
+or, if you prefer to use Maven:
+
+```
+mvn lagom:runAll
+```
+
 ## Shopping cart service
 
 The shopping cart service offers three REST endpoints:


### PR DESCRIPTION
The project contains both sbt and Maven build files, but the README only documented the sbt build.