### PR TITLE
Translate dots in branch name to hyphens

### DIFF
--- a/shopping-cart/deploy/scripts/common/deployment-tools.sh
+++ b/shopping-cart/deploy/scripts/common/deployment-tools.sh
@@ -168,7 +168,11 @@ buildRoute() {
   ##
   ## The hostname is set to '${SERVICE_NAME}-$NAMESPACE.$OPENSHIFT_SERVER', since that's
   ## the convention used by openshift when using `oc expose service`.
-  ## The hostname is truncated after 63 characters, the maximum length for a DNS hostname.
   local hostname="${SERVICE_NAME}-$NAMESPACE"
-  oc create route edge --service=$SERVICE_NAME --hostname=${hostname:0:63}.$OPENSHIFT_SERVER  || exit 1
+  ## The hostname is truncated after 63 characters, the maximum length for a DNS hostname.
+  hostname=${hostname:0:63}
+  ## Hostnames can't end with a hyphen, so remove any trailing hyphens
+  shopt -s extglob # required to enable the below pattern to match multiple hyphens
+  hostname=${hostname%%+(-)}
+  oc create route edge --service=$SERVICE_NAME --hostname=${hostname}.$OPENSHIFT_SERVER  || exit 1
 }

--- a/shopping-cart/deploy/scripts/common/setupEnv.sh
+++ b/shopping-cart/deploy/scripts/common/setupEnv.sh
@@ -1,5 +1,17 @@
 #!/bin/bash
 
+## The ID will be the PR number, the branch name on Travis or `local`
+if [[ -n "${TRAVIS_PULL_REQUEST}" && "${TRAVIS_PULL_REQUEST}" != false ]]
+then
+    ID="${TRAVIS_PULL_REQUEST}" # Pull request number
+elif [[ -n "${TRAVIS_BRANCH}" ]]
+then
+    ID="${TRAVIS_BRANCH//./-}" # Branch name, with dots replaced by hyphens
+else
+    ID=local
+fi
+export NAMESPACE=lagom-$CODE_VARIANT-$BUILD_TOOL-$USER-$ID
+
 # Setup env vars for deployment
 export OPENSHIFT_SERVER=centralpark2.lightbend.com
 ## Must not use `DOCKER_REGISTRY` as the name of the ENV VAR since it clashes 

--- a/shopping-cart/deploy/scripts/common/setupEnv.sh
+++ b/shopping-cart/deploy/scripts/common/setupEnv.sh
@@ -11,6 +11,9 @@ else
     ID=local
 fi
 export NAMESPACE=lagom-$CODE_VARIANT-$BUILD_TOOL-$USER-$ID
+## The NAMESPACE is truncated after 63 characters, the maximum length for an OpenShift project name.
+NAMESPACE=${NAMESPACE:0:63}
+
 
 # Setup env vars for deployment
 export OPENSHIFT_SERVER=centralpark2.lightbend.com

--- a/shopping-cart/deploy/scripts/deploy-shopping-cart.sh
+++ b/shopping-cart/deploy/scripts/deploy-shopping-cart.sh
@@ -10,9 +10,6 @@ shift
 BUILD_TOOL=${1:-sbt}
 
 
-## The ID will be the PR number, the branch name on Travis or `local`
-ID="$(sed "s/false/$TRAVIS_BRANCH/" <<<${TRAVIS_PULL_REQUEST:-local})"
-
 # Recognize the environment
 SCRIPTS_DIR=$( cd "$( dirname "${BASH_SOURCE[0]}" )" && pwd )
 COMMON_SCRIPTS_DIR=$SCRIPTS_DIR/common
@@ -25,13 +22,9 @@ SHOPPING_CART_SOURCES=$BASE_DIR/$CODE_VARIANT
 . $COMMON_SCRIPTS_DIR/installers.sh
 installOC
 
-# 0. Setup the NAMESPACE (predates all)
-#   e.g. lagom-shopping-cart-scala-sbt-23  (23 is the PR number)
-export NAMESPACE=lagom-$CODE_VARIANT-$BUILD_TOOL-$USER-$ID
-echo "Deploying to $NAMESPACE"
-
 # 1. Setup session and load some helping functions
 . $COMMON_SCRIPTS_DIR/setupEnv.sh
+echo "Deploying to $NAMESPACE"
 . $COMMON_SCRIPTS_DIR/clusterLogin.sh
 
 # 2. Load extra tools to manage the deployment

--- a/shopping-cart/deploy/scripts/test-shopping-cart.sh
+++ b/shopping-cart/deploy/scripts/test-shopping-cart.sh
@@ -9,8 +9,6 @@ CODE_VARIANT=${1:-shopping-cart-scala}
 shift 
 BUILD_TOOL=${1:-sbt}
 
-## The ID will be the PR number, the branch name on Travis or `local`
-ID="$(sed "s/false/$TRAVIS_BRANCH/" <<<${TRAVIS_PULL_REQUEST:-local})"
 
 # Recognize the environment
 SCRIPTS_DIR=$( cd "$( dirname "${BASH_SOURCE[0]}" )" && pwd )
@@ -20,13 +18,9 @@ DEPLOY_DIR=$SCRIPTS_DIR/..
 BASE_DIR=$DEPLOY_DIR/..
 SHOPPING_CART_SOURCES=$BASE_DIR/$CODE_VARIANT
 
-# 0. Setup the NAMESPACE (predates all)
-#   e.g. lagom-shopping-cart-scala-sbt-23  (23 is the PR number)
-export NAMESPACE=lagom-$CODE_VARIANT-$BUILD_TOOL-$USER-$ID
-echo "Testing deployment $NAMESPACE"
-
 # 1. Setup session and load some helping functions
 . $COMMON_SCRIPTS_DIR/setupEnv.sh
+echo "Testing deployment $NAMESPACE"
 . $COMMON_SCRIPTS_DIR/clusterLogin.sh
 
 # 2. Load extra tools to manage the deployment


### PR DESCRIPTION
This fixes the broken build on the 1.5.x branch.

Replaces #69.