### PR TITLE
Switch to using ServiceAccount kind in RoleBinding

### DIFF
--- a/shopping-cart/deploy/specs/common/rbac.yaml
+++ b/shopping-cart/deploy/specs/common/rbac.yaml
@@ -12,8 +12,8 @@ apiVersion: rbac.authorization.k8s.io/v1
 metadata:
   name: read-pods
 subjects:
-- kind: User
-  name: system:serviceaccount:myproject:default
+- kind: ServiceAccount
+  name: default
 roleRef:
   kind: Role
   name: pod-reader


### PR DESCRIPTION
See https://github.com/akka/akka-management/pull/558. This means it doesn't matter what project/namespace you're using, the rbac.yaml can be deployed to any namespace without editing it, since when you use `ServiceAccount` kinds in role binding, the namespace defaults to the namespace the role binding is deployed to.