### PR TITLE
Only build PRs and main branches

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,5 +1,9 @@
 language: scala
 
+# Only build non-pushes (so PRs, API requests & cron jobs) OR tags OR forks OR main branch builds
+# https://docs.travis-ci.com/user/conditional-builds-stages-jobs/
+if: type != push OR repo != lagom/lagom-samples OR branch IN (1.5.x, 1.6.x)
+
 before_install:
   # See https://github.com/travis-ci/travis-ci/issues/4629#issuecomment-239493916
   - rm ~/.m2/settings.xml


### PR DESCRIPTION
In this repo we should prefer PR from branches instead of forks because of Central Park deployments. 

This PR avoids double Travis builds by excluding the branches and only building the PRs. 