### PR TITLE
Add link to lagom.js example

### DIFF
--- a/README.md
+++ b/README.md
@@ -21,6 +21,7 @@ This repository contains code examples to help you understand how to achieve com
 * How do I generate _OpenAPI/Swagger Specification_ for Lagom service? ([Java/Maven example](https://github.com/taymyr/lagom-samples/blob/master/openapi/java/README.md), [Scala/Sbt example](https://github.com/taymyr/lagom-samples/blob/master/openapi/scala/README.md))
 * How do I using Play's JPA API to do CRUD-oriented persistence in a Lagom service? ([Java/SBT example](https://github.com/taymyr/lagom-samples/blob/master/jpa-crud/java-sbt/README.md))
 * How do I use MongoDB as read-side in a Lagom service? ([Scala/SBT example](https://github.com/abknanda/mongo-readside-lagom))
+* How do I use a Lagom service in JavaScript? ([Scala/SBT example](https://github.com/mliarakos/lagom-scalajs-example))
 
 ## Contributing examples
 


### PR DESCRIPTION
Add an [example](https://github.com/mliarakos/lagom-scalajs-example) on how to use [lagom.js](https://github.com/mliarakos/lagom-js) to interact with a Lagom service in JavaScript.