### PR TITLE
Partitioned event tags

### DIFF
--- a/shopping-cart/shopping-cart-java/shopping-cart/src/main/java/com/example/shoppingcart/impl/ShoppingCartEvent.java
+++ b/shopping-cart/shopping-cart-java/shopping-cart/src/main/java/com/example/shoppingcart/impl/ShoppingCartEvent.java
@@ -6,22 +6,25 @@ import com.google.common.base.Preconditions;
 import com.lightbend.lagom.javadsl.persistence.AggregateEvent;
 import com.lightbend.lagom.javadsl.persistence.AggregateEventTag;
 import com.lightbend.lagom.javadsl.persistence.AggregateEventTagger;
+import com.lightbend.lagom.javadsl.persistence.AggregateEventShards;
 import com.lightbend.lagom.serialization.Jsonable;
 import lombok.Value;
 
 import java.time.Instant;
 
 /**
- * This interface defines all the events that the {@link ShoppingCartEntity} supports.
+ * This interface defines all the events that the {@link ShoppingCartEntity}
+ * supports.
  * <p>
  * By convention, the events should be inner classes of the interface, which
  * makes it simple to get a complete picture of what events an entity has.
  */
 public interface ShoppingCartEvent extends Jsonable, AggregateEvent<ShoppingCartEvent> {
     /**
-     * The tag for shopping cart events, used for consuming the Journal event stream later.
+     * The tag for shopping cart events, used for consuming the Journal event stream
+     * later.
      */
-    AggregateEventTag<ShoppingCartEvent> TAG = AggregateEventTag.of(ShoppingCartEvent.class);
+    AggregateEventShards<ShoppingCartEvent> TAG = AggregateEventTag.sharded(ShoppingCartEvent.class, 10);
 
     /**
      * An event that represents a item updated event.

--- a/shopping-cart/shopping-cart-java/shopping-cart/src/main/java/com/example/shoppingcart/impl/ShoppingCartReportProcessor.java
+++ b/shopping-cart/shopping-cart-java/shopping-cart/src/main/java/com/example/shoppingcart/impl/ShoppingCartReportProcessor.java
@@ -23,22 +23,17 @@ public class ShoppingCartReportProcessor extends ReadSideProcessor<ShoppingCartE
         this.jpaReadSide = jpaReadSide;
     }
 
-
     @Override
     public ReadSideHandler<ShoppingCartEvent> buildHandler() {
-        return jpaReadSide
-                .<ShoppingCartEvent>builder("shopping-cart-report")
-                .setGlobalPrepare(this::createSchema)
+        return jpaReadSide.<ShoppingCartEvent>builder("shopping-cart-report").setGlobalPrepare(this::createSchema)
                 .setEventHandler(ShoppingCartEvent.ItemUpdated.class, this::createReport)
-                .setEventHandler(ShoppingCartEvent.CheckedOut.class, this::addCheckoutTime)
-                .build();
+                .setEventHandler(ShoppingCartEvent.CheckedOut.class, this::addCheckoutTime).build();
     }
 
     private void createSchema(@SuppressWarnings("unused") EntityManager ignored) {
         Persistence.generateSchema("default", ImmutableMap.of("hibernate.hbm2ddl.auto", "update"));
     }
 
-    
     private void createReport(EntityManager entityManager, ShoppingCartEvent.ItemUpdated evt) {
 
         logger.debug("Received ItemUpdate event: " + evt);
@@ -63,14 +58,14 @@ public class ShoppingCartReportProcessor extends ReadSideProcessor<ShoppingCartE
             throw new RuntimeException("Didn't find cart for checkout. CartID: " + evt.shoppingCartId);
         }
     }
+
     private ShoppingCartReport findReport(EntityManager entityManager, String cartId) {
         return entityManager.find(ShoppingCartReport.class, cartId);
     }
 
-
     @Override
     public PSequence<AggregateEventTag<ShoppingCartEvent>> aggregateTags() {
-        return TreePVector.singleton(ShoppingCartEvent.TAG);
+        return ShoppingCartEvent.TAG.allTags();
     }
 
 }

--- a/shopping-cart/shopping-cart-scala/shopping-cart/src/main/scala/com/example/shoppingcart/impl/ShoppingCartEntity.scala
+++ b/shopping-cart/shopping-cart-scala/shopping-cart/src/main/scala/com/example/shoppingcart/impl/ShoppingCartEntity.scala
@@ -180,7 +180,7 @@ sealed trait ShoppingCartEvent extends AggregateEvent[ShoppingCartEvent] {
 }
 
 object ShoppingCartEvent {
-  val Tag = AggregateEventTag[ShoppingCartEvent]
+  val Tag = AggregateEventTag.sharded[ShoppingCartEvent](10)
 }
 
 /**

--- a/shopping-cart/shopping-cart-scala/shopping-cart/src/main/scala/com/example/shoppingcart/impl/ShoppingCartReportProcessor.scala
+++ b/shopping-cart/shopping-cart-scala/shopping-cart/src/main/scala/com/example/shoppingcart/impl/ShoppingCartReportProcessor.scala
@@ -19,5 +19,5 @@ class ShoppingCartReportProcessor(readSide: SlickReadSide,
       }
       .build()
 
-  override def aggregateTags = Set(ShoppingCartEvent.Tag)
+  override def aggregateTags = ShoppingCartEvent.Tag.allTags
 }

--- a/shopping-cart/shopping-cart-scala/shopping-cart/src/main/scala/com/example/shoppingcart/impl/ShoppingCartServiceImpl.scala
+++ b/shopping-cart/shopping-cart-scala/shopping-cart/src/main/scala/com/example/shoppingcart/impl/ShoppingCartServiceImpl.scala
@@ -45,8 +45,8 @@ class ShoppingCartServiceImpl(persistentEntityRegistry: PersistentEntityRegistry
       }
   }
 
-  override def shoppingCartTopic: Topic[ShoppingCart] = TopicProducer.singleStreamWithOffset { fromOffset =>
-    persistentEntityRegistry.eventStream(ShoppingCartEvent.Tag, fromOffset)
+  override def shoppingCartTopic: Topic[ShoppingCart] = TopicProducer.taggedStreamWithOffset(ShoppingCartEvent.Tag) { (tag, fromOffset) =>
+    persistentEntityRegistry.eventStream(tag, fromOffset)
       .filter(_.event.isInstanceOf[CheckedOut])
       .mapAsync(4) {
         case EventStreamElement(id, _, offset) =>


### PR DESCRIPTION
This PR introduces partitioned tags for the shopping cart samples (scala and java). 

This is useful in itself because is the recommended way of tagging events. In addition to that, we want to have it partitioned so we can validate a migration to Akka Persistence Typed as we must make sure that the tags are partitioned exactly the same.