### PR TITLE
Migration to Akka Persistence Typed

### DIFF
--- a/shopping-cart/shopping-cart-java/build.sbt
+++ b/shopping-cart/shopping-cart-java/build.sbt
@@ -13,6 +13,17 @@ val hibernateEntityManager = "org.hibernate" % "hibernate-entitymanager" % "5.4.
 val jpaApi  = "org.hibernate.javax.persistence" % "hibernate-jpa-2.1-api" % "1.0.0.Final"
 val validationApi = "javax.validation" % "validation-api" % "1.1.0.Final"
 
+
+lazy val akkaVersion         = "2.6.0-M7"
+val akkaPersistenceTyped     = "com.typesafe.akka" %% "akka-persistence-typed" % akkaVersion
+val akkaShardingTyped        = "com.typesafe.akka" %% "akka-cluster-sharding-typed" % akkaVersion
+val akkaSerializationJackson = "com.typesafe.akka" %% "akka-serialization-jackson" % akkaVersion
+val akkaDiscovery            = "com.typesafe.akka" %% "akka-discovery" % akkaVersion
+val akkaProtobuf             = "com.typesafe.akka" %% "akka-protobuf" % akkaVersion
+val akkaPersistenceQuery     = "com.typesafe.akka" %% "akka-persistence-query" % akkaVersion
+val akkaTestkit              = "com.typesafe.akka" %% "akka-stream-testkit" % akkaVersion
+
+
 lazy val `shopping-cart-java` = (project in file("."))
   .aggregate(`shopping-cart-api`, `shopping-cart`, `inventory-api`, inventory)
 
@@ -41,6 +52,12 @@ lazy val `shopping-cart` = (project in file("shopping-cart"))
       hamcrestLibrary,
       lagomJavadslAkkaDiscovery,
       akkaDiscoveryKubernetesApi,
+      akkaShardingTyped,
+      akkaPersistenceTyped,
+      akkaSerializationJackson,
+      akkaDiscovery,
+      akkaProtobuf,
+      akkaPersistenceQuery,
       hibernateEntityManager,
       jpaApi,
       validationApi

--- a/shopping-cart/shopping-cart-java/shopping-cart/src/main/java/com/example/shoppingcart/impl/LagomTaggerAdapter.java
+++ b/shopping-cart/shopping-cart-java/shopping-cart/src/main/java/com/example/shoppingcart/impl/LagomTaggerAdapter.java
@@ -1,0 +1,26 @@
+package com.example.shoppingcart.impl;
+
+import com.lightbend.lagom.javadsl.persistence.AggregateEvent;
+import com.lightbend.lagom.javadsl.persistence.AggregateEventShards;
+import com.lightbend.lagom.javadsl.persistence.AggregateEventTag;
+import com.lightbend.lagom.javadsl.persistence.AggregateEventTagger;
+
+import java.util.HashSet;
+import java.util.Set;
+import java.util.function.Function;
+
+public class LagomTaggerAdapter {
+
+    public static <Event extends AggregateEvent<Event>> Function<Event, Set<String>> adapt(String businessId, AggregateEventTagger<Event> lagomTagger) {
+        return evt -> {
+            Set<String> tags = new HashSet<>();
+            if (lagomTagger instanceof AggregateEventTag) {
+                tags.add(((AggregateEventTag) lagomTagger).tag());
+            } else if (lagomTagger instanceof AggregateEventShards) {
+                tags.add(((AggregateEventShards) lagomTagger).forEntityId(businessId).tag());
+            }
+            return tags;
+        };
+
+    }
+}

--- a/shopping-cart/shopping-cart-java/shopping-cart/src/main/java/com/example/shoppingcart/impl/ShoppingCartEntity.java
+++ b/shopping-cart/shopping-cart-java/shopping-cart/src/main/java/com/example/shoppingcart/impl/ShoppingCartEntity.java
@@ -1,110 +1,131 @@
 package com.example.shoppingcart.impl;
 
-import akka.Done;
+import akka.actor.typed.Behavior;
+import akka.cluster.sharding.typed.javadsl.EntityContext;
+import akka.cluster.sharding.typed.javadsl.EntityTypeKey;
+import akka.persistence.typed.PersistenceId;
+import akka.persistence.typed.javadsl.*;
 import com.example.shoppingcart.impl.ShoppingCartCommand.Checkout;
 import com.example.shoppingcart.impl.ShoppingCartCommand.Get;
 import com.example.shoppingcart.impl.ShoppingCartCommand.UpdateItem;
 import com.example.shoppingcart.impl.ShoppingCartEvent.CheckedOut;
 import com.example.shoppingcart.impl.ShoppingCartEvent.ItemUpdated;
-import com.lightbend.lagom.javadsl.persistence.PersistentEntity;
+import com.example.shoppingcart.impl.ShoppingCartReply.*;
 
 import java.time.Instant;
-import java.util.Optional;
+import java.util.Set;
 
 /**
  * This is an event sourced entity. It has a state, {@link ShoppingCartState}, which
  * stores the current shopping cart items and whether it's checked out.
- *
+ * <p>
  * Event sourced entities are interacted with by sending them commands. This
  * entity supports three commands, an {@link UpdateItem} command, which is used to
  * update the quantity of an item in the cart, a {@link Checkout} command which is
  * used to set checkout the shopping cart, and a {@link Get} command, which is a read
  * only command which returns the current shopping cart state.
- *
+ * <p>
  * Commands get translated to events, and it's the events that get persisted by
  * the entity. Each event will have an event handler registered for it, and an
  * event handler simply applies an event to the current state. This will be done
  * when the event is first created, and it will also be done when the entity is
  * loaded from the database - each event will be replayed to recreate the state
  * of the entity.
- *
+ * <p>
  * This entity defines two events, the {@link ItemUpdated} event, which is emitted
  * when a {@link UpdateItem} command is received, and a {@link CheckedOut} event, which
  * is emitted when a {@link Checkout} command is received.
  */
-public class ShoppingCartEntity extends PersistentEntity<ShoppingCartCommand, ShoppingCartEvent, ShoppingCartState> {
-    /**
-     * An entity can define different behaviours for different states, but it will
-     * always start with an initial behaviour. This entity only has one behaviour.
-     */
+public class ShoppingCartEntity extends EventSourcedBehaviorWithEnforcedReplies<ShoppingCartCommand, ShoppingCartEvent, ShoppingCartState> {
+
+    // We need to keep the original business id because that's the one we should
+    // use when tagging. If we use the PersistenceId, we will change the tag shard
+    private final String businessId;
+
+    ShoppingCartEntity(String businessId) {
+        this(businessId, ENTITY_TYPE_KEY.persistenceIdFrom(businessId));
+    }
+
+    private ShoppingCartEntity(String businessId, PersistenceId persistenceId) {
+        super(persistenceId);
+        this.businessId = businessId;
+    }
+
+    public static EntityTypeKey<ShoppingCartCommand> ENTITY_TYPE_KEY =
+        EntityTypeKey
+                .create(ShoppingCartCommand.class, "ShoppingCartEntity")
+                .withEntityIdSeparator(""); // <- this is important for LagomJava, separator must be an empty String
+
+    public static ShoppingCartEntity behavior(EntityContext<ShoppingCartCommand> entityContext) {
+        return new ShoppingCartEntity(entityContext.getEntityId());
+    }
+
     @Override
-    public Behavior initialBehavior(Optional<ShoppingCartState> snapshotState) {
-
-        ShoppingCartState state = snapshotState.orElse(ShoppingCartState.EMPTY);
-        BehaviorBuilder b = newBehaviorBuilder(state);
-
-        if (state.isCheckedOut()) {
-            return checkedOut(b);
-        } else {
-            return openShoppingCart(b);
-        }
+    public ShoppingCartState emptyState() {
+        return ShoppingCartState.EMPTY;
     }
 
-    /**
-     * Create a behavior for the open shopping cart state.
-     */
-    private Behavior openShoppingCart(BehaviorBuilder b) {
-        // Command handler for the UpdateItem command
-        b.setCommandHandler(UpdateItem.class, (cmd, ctx) -> {
-            if (cmd.getQuantity() < 0) {
-                ctx.commandFailed(new ShoppingCartException("Quantity must be greater than zero"));
-                return ctx.done();
-            } else if (cmd.getQuantity() == 0 && !state().getItems().containsKey(cmd.getProductId())) {
-                ctx.commandFailed(new ShoppingCartException("Cannot delete item that is not already in cart"));
-                return ctx.done();
-            } else {
-                return ctx.thenPersist(new ItemUpdated(entityId(), cmd.getProductId(), cmd.getQuantity(), Instant.now()), e -> ctx.reply(Done.getInstance()));
-            }
-        });
+    @Override
+    public CommandHandlerWithReply<ShoppingCartCommand, ShoppingCartEvent, ShoppingCartState> commandHandler() {
 
-        // Command handler for the Checkout command
-        b.setCommandHandler(Checkout.class, (cmd, ctx) -> {
-            if (state().getItems().isEmpty()) {
-                ctx.commandFailed(new ShoppingCartException("Cannot checkout empty cart"));
-                return ctx.done();
-            } else {
-                return ctx.thenPersist(new CheckedOut(entityId(), Instant.now()), e -> ctx.reply(Done.getInstance()));
-            }
-        });
-        commonHandlers(b);
-        return b.build();
+        CommandHandlerWithReplyBuilder<ShoppingCartCommand, ShoppingCartEvent, ShoppingCartState> builder = newCommandHandlerWithReplyBuilder();
+
+        // Create a behavior for the open shopping cart state.
+        builder.forState(ShoppingCartState::isOpen)
+                .onCommand(UpdateItem.class, (state, cmd) -> {
+
+                    if (cmd.getQuantity() < 0) {
+                        return Effect()
+                                .reply(cmd, new Rejected("Quantity must be greater than zero"));
+
+                    } else if( cmd.getQuantity() == 0 && !state.getItems().containsKey(cmd.getProductId())) {
+                        return Effect()
+                                .reply(cmd, new Rejected("Cannot delete item that is not already in cart"));
+
+                    }else {
+                        return Effect()
+                                .persist(new ItemUpdated(businessId, cmd.getProductId(), cmd.getQuantity(), Instant.now()))
+                                .thenReply(cmd, __ -> new Accepted());
+                    }
+                })
+                .onCommand(Checkout.class, (state, cmd) -> {
+                    if (state.getItems().isEmpty()) {
+                        return Effect()
+                                .reply(cmd, new Rejected("Cannot checkout empty cart"));
+
+                    } else {
+                        return Effect()
+                                .persist(new CheckedOut(businessId, Instant.now()))
+                                .thenReply(cmd, __ -> new Accepted());
+                    }
+                });
+
+
+        // Create a behavior for the checked out state.
+        builder.forState(ShoppingCartState::isCheckedOut)
+                .onCommand(UpdateItem.class,
+                        cmd -> Effect().reply(cmd, new Rejected("Can't update item on already checked out shopping cart")))
+                .onCommand(Checkout.class,
+                        cmd -> Effect().reply(cmd, new Rejected("Can't checkout on already checked out shopping cart")));
+
+
+        builder.forAnyState().onCommand(Get.class, (state, cmd) -> Effect().reply(cmd, new CurrentState(state)));
+
+        return builder.build();
     }
 
-    /**
-     * Create a behavior for the checked out state.
-     */
-    private Behavior checkedOut(BehaviorBuilder b) {
-        b.setReadOnlyCommandHandler(UpdateItem.class, (cmd, ctx) ->
-            ctx.commandFailed(new ShoppingCartException("Can't update item on already checked out shopping cart"))
-        );
-        b.setReadOnlyCommandHandler(Checkout.class, (cmd, ctx) ->
-            ctx.commandFailed(new ShoppingCartException("Can't checkout on already checked out shopping cart"))
-        );
-        commonHandlers(b);
-        return b.build();
+    @Override
+    public EventHandler<ShoppingCartState, ShoppingCartEvent> eventHandler() {
+
+        return newEventHandlerBuilder().forAnyState()
+            .onEvent(ItemUpdated.class, (state, evt) -> state.updateItem(evt.getProductId(), evt.getQuantity()))
+            .onEvent(CheckedOut.class, (state, evt) -> state.checkout())
+        .build();
     }
 
-    /**
-     * Add all the handlers that are shared across all states to the behavior builder.
-     */
-    private void commonHandlers(BehaviorBuilder b) {
-        b.setReadOnlyCommandHandler(Get.class, (cmd, ctx) -> ctx.reply(state()));
 
-        b.setEventHandler(ItemUpdated.class, itemUpdated ->
-            state().updateItem(itemUpdated.getProductId(), itemUpdated.getQuantity()));
-
-        b.setEventHandlerChangingBehavior(CheckedOut.class, e ->
-            checkedOut(newBehaviorBuilder(state().checkout())));
+    @Override
+    public Set<String> tagsFor(ShoppingCartEvent shoppingCartEvent) {
+        return LagomTaggerAdapter.adapt(businessId, ShoppingCartEvent.TAG).apply(shoppingCartEvent);
     }
-
 }

--- a/shopping-cart/shopping-cart-java/shopping-cart/src/main/java/com/example/shoppingcart/impl/ShoppingCartEvent.java
+++ b/shopping-cart/shopping-cart-java/shopping-cart/src/main/java/com/example/shoppingcart/impl/ShoppingCartEvent.java
@@ -4,6 +4,7 @@ import com.fasterxml.jackson.annotation.JsonCreator;
 import com.fasterxml.jackson.databind.annotation.JsonDeserialize;
 import com.google.common.base.Preconditions;
 import com.lightbend.lagom.javadsl.persistence.AggregateEvent;
+import com.lightbend.lagom.javadsl.persistence.AggregateEventShards;
 import com.lightbend.lagom.javadsl.persistence.AggregateEventTag;
 import com.lightbend.lagom.javadsl.persistence.AggregateEventTagger;
 import com.lightbend.lagom.serialization.Jsonable;
@@ -21,7 +22,7 @@ public interface ShoppingCartEvent extends Jsonable, AggregateEvent<ShoppingCart
     /**
      * The tag for shopping cart events, used for consuming the Journal event stream later.
      */
-    AggregateEventTag<ShoppingCartEvent> TAG = AggregateEventTag.of(ShoppingCartEvent.class);
+    AggregateEventShards<ShoppingCartEvent> TAG = AggregateEventTag.sharded(ShoppingCartEvent.class, 10);
 
     /**
      * An event that represents a item updated event.

--- a/shopping-cart/shopping-cart-java/shopping-cart/src/main/java/com/example/shoppingcart/impl/ShoppingCartReply.java
+++ b/shopping-cart/shopping-cart-java/shopping-cart/src/main/java/com/example/shoppingcart/impl/ShoppingCartReply.java
@@ -1,0 +1,43 @@
+package com.example.shoppingcart.impl;
+
+
+import com.fasterxml.jackson.annotation.JsonCreator;
+import com.fasterxml.jackson.databind.annotation.JsonDeserialize;
+import lombok.Value;
+
+public interface ShoppingCartReply {
+
+
+    @Value
+    @JsonDeserialize
+    final class CurrentState implements ShoppingCartReply{
+        private final ShoppingCartState shoppingCartState;
+
+        @JsonCreator
+        public CurrentState(ShoppingCartState shoppingCartState) {
+            this.shoppingCartState = shoppingCartState;
+        }
+    }
+
+    interface Confirmation extends ShoppingCartReply {}
+
+    @Value
+    @JsonDeserialize
+    final class Accepted implements Confirmation {
+        @JsonCreator
+        public Accepted() {
+        }
+    }
+
+    @Value
+    @JsonDeserialize
+    final class Rejected implements Confirmation {
+        private final String reason;
+
+        @JsonCreator
+        public Rejected(String reason) {
+            this.reason = reason;
+        }
+    }
+
+}

--- a/shopping-cart/shopping-cart-java/shopping-cart/src/main/java/com/example/shoppingcart/impl/ShoppingCartReportProcessor.java
+++ b/shopping-cart/shopping-cart-java/shopping-cart/src/main/java/com/example/shoppingcart/impl/ShoppingCartReportProcessor.java
@@ -70,7 +70,7 @@ public class ShoppingCartReportProcessor extends ReadSideProcessor<ShoppingCartE
 
     @Override
     public PSequence<AggregateEventTag<ShoppingCartEvent>> aggregateTags() {
-        return TreePVector.singleton(ShoppingCartEvent.TAG);
+        return ShoppingCartEvent.TAG.allTags();
     }
 
 }

--- a/shopping-cart/shopping-cart-java/shopping-cart/src/main/java/com/example/shoppingcart/impl/ShoppingCartState.java
+++ b/shopping-cart/shopping-cart-java/shopping-cart/src/main/java/com/example/shoppingcart/impl/ShoppingCartState.java
@@ -15,6 +15,7 @@ import org.pcollections.PMap;
 @Value
 @JsonDeserialize
 public final class ShoppingCartState implements CompressedJsonable {
+
     public final PMap<String, Integer> items;
     public final boolean checkedOut;
 
@@ -38,5 +39,8 @@ public final class ShoppingCartState implements CompressedJsonable {
         return new ShoppingCartState(items, true);
     }
 
+    public boolean isOpen() {
+        return !this.checkedOut;
+    }
     public static final ShoppingCartState EMPTY = new ShoppingCartState(HashTreePMap.empty(), false);
 }

--- a/shopping-cart/shopping-cart-java/shopping-cart/src/main/java/lagom/cluster/sharding/typed/ClusterShardingModule.scala
+++ b/shopping-cart/shopping-cart-java/shopping-cart/src/main/java/lagom/cluster/sharding/typed/ClusterShardingModule.scala
@@ -1,0 +1,25 @@
+/*
+ * Copyright (C) 2009-2019 Lightbend Inc. <https://www.lightbend.com>
+ */
+
+package lagom.cluster.sharding.typed
+
+import akka.cluster.sharding.typed.javadsl.ClusterSharding
+import play.api.inject._
+import javax.inject.Inject
+import javax.inject.Provider
+import javax.inject.Singleton
+import akka.actor.typed.javadsl.Adapter
+import akka.actor.ActorSystem
+import akka.annotation.InternalApi
+
+@InternalApi
+final class ClusterShardingModule extends SimpleModule(bind[ClusterSharding].toProvider[ClusterShardingProvider])
+
+/** Provider for the Akka Typed ClusterSharding (Java) */
+@Singleton
+@InternalApi
+class ClusterShardingProvider @Inject()(val actorSystem: ActorSystem) extends Provider[ClusterSharding] {
+  private val sharding       = ClusterSharding.get(Adapter.toTyped(actorSystem))
+  def get(): ClusterSharding = sharding
+}

--- a/shopping-cart/shopping-cart-java/shopping-cart/src/main/resources/application.conf
+++ b/shopping-cart/shopping-cart-java/shopping-cart/src/main/resources/application.conf
@@ -1,4 +1,6 @@
 play.modules.enabled += com.example.shoppingcart.impl.ShoppingCartModule
+play.modules.enabled += lagom.cluster.sharding.typed.ClusterShardingModule
+
 
 db.default {
   driver = "org.postgresql.Driver"

--- a/shopping-cart/shopping-cart-scala/build.sbt
+++ b/shopping-cart/shopping-cart-scala/build.sbt
@@ -11,6 +11,15 @@ val scalaTest = "org.scalatest" %% "scalatest" % "3.0.8" % Test
 val akkaDiscoveryKubernetesApi = "com.lightbend.akka.discovery" %% "akka-discovery-kubernetes-api" % "1.0.1"
 val lagomScaladslAkkaDiscovery = "com.lightbend.lagom" %% "lagom-scaladsl-akka-discovery-service-locator" % LagomVersion.current
 
+lazy val akkaVersion         = "2.6.0-M7"
+val akkaPersistenceTyped     = "com.typesafe.akka" %% "akka-persistence-typed" % akkaVersion
+val akkaShardingTyped        = "com.typesafe.akka" %% "akka-cluster-sharding-typed" % akkaVersion
+val akkaSerializationJackson = "com.typesafe.akka" %% "akka-serialization-jackson" % akkaVersion
+val akkaDiscovery            = "com.typesafe.akka" %% "akka-discovery" % akkaVersion
+val akkaProtobuf             = "com.typesafe.akka" %% "akka-protobuf" % akkaVersion
+val akkaPersistenceQuery     = "com.typesafe.akka" %% "akka-persistence-query" % akkaVersion
+val akkaTestkit              = "com.typesafe.akka" %% "akka-stream-testkit" % akkaVersion
+
 ThisBuild / scalacOptions ++= List("-encoding", "utf8", "-deprecation", "-feature", "-unchecked", "-Xfatal-warnings")
 
 def dockerSettings = Seq(
@@ -41,6 +50,12 @@ lazy val `shopping-cart` = (project in file("shopping-cart"))
       lagomScaladslPersistenceJdbc,
       lagomScaladslKafkaBroker,
       lagomScaladslTestKit,
+      akkaShardingTyped,
+      akkaPersistenceTyped,
+      akkaSerializationJackson,
+      akkaDiscovery,
+      akkaProtobuf,
+      akkaPersistenceQuery,
       macwire,
       scalaTest,
       postgresDriver,

--- a/shopping-cart/shopping-cart-scala/inventory/src/main/scala/com/example/inventory/impl/InventoryServiceImpl.scala
+++ b/shopping-cart/shopping-cart-scala/inventory/src/main/scala/com/example/inventory/impl/InventoryServiceImpl.scala
@@ -3,20 +3,22 @@ package com.example.inventory.impl
 import java.util.concurrent.atomic.AtomicInteger
 
 import akka.stream.scaladsl.Flow
-import akka.{Done, NotUsed}
+import akka.Done
+import akka.NotUsed
 import com.lightbend.lagom.scaladsl.api.ServiceCall
 import com.example.inventory.api.InventoryService
-import com.example.shoppingcart.api.{ShoppingCart, ShoppingCartService}
+import com.example.shoppingcart.api.ShoppingCart
+import com.example.shoppingcart.api.ShoppingCartService
 
 import scala.collection.concurrent.TrieMap
 import scala.concurrent.Future
 
 /**
-  * Implementation of the inventory service.
-  *
-  * This just stores the inventory in memory, so it will be lost on restart, and also won't work
-  * with more than one replicas, but it's enough to demonstrate things working.
-  */
+ * Implementation of the inventory service.
+ *
+ * This just stores the inventory in memory, so it will be lost on restart, and also won't work
+ * with more than one replicas, but it's enough to demonstrate things working.
+ */
 class InventoryServiceImpl(shoppingCartService: ShoppingCartService) extends InventoryService {
 
   private val inventory = TrieMap.empty[String, AtomicInteger]

--- a/shopping-cart/shopping-cart-scala/shopping-cart-api/src/main/scala/com/example/shoppingcart/api/ShoppingCartService.scala
+++ b/shopping-cart/shopping-cart-scala/shopping-cart-api/src/main/scala/com/example/shoppingcart/api/ShoppingCartService.scala
@@ -2,30 +2,34 @@ package com.example.shoppingcart.api
 
 import java.time.Instant
 
-import akka.{Done, NotUsed}
+import akka.Done
+import akka.NotUsed
 import com.lightbend.lagom.scaladsl.api.broker.Topic
-import com.lightbend.lagom.scaladsl.api.broker.kafka.{KafkaProperties, PartitionKeyStrategy}
+import com.lightbend.lagom.scaladsl.api.broker.kafka.KafkaProperties
+import com.lightbend.lagom.scaladsl.api.broker.kafka.PartitionKeyStrategy
 import com.lightbend.lagom.scaladsl.api.transport.Method
-import com.lightbend.lagom.scaladsl.api.{Service, ServiceCall}
-import play.api.libs.json.{Format, Json}
+import com.lightbend.lagom.scaladsl.api.Service
+import com.lightbend.lagom.scaladsl.api.ServiceCall
+import play.api.libs.json.Format
+import play.api.libs.json.Json
 
-object ShoppingCartService  {
+object ShoppingCartService {
   val TOPIC_NAME = "shopping-cart"
 }
 
 /**
-  * The ShoppingCart service interface.
-  * <p>
-  * This describes everything that Lagom needs to know about how to serve and
-  * consume the ShoppingCartService.
-  */
+ * The ShoppingCart service interface.
+ * <p>
+ * This describes everything that Lagom needs to know about how to serve and
+ * consume the ShoppingCartService.
+ */
 trait ShoppingCartService extends Service {
 
   /**
-    * Get a shopping cart.
-    *
-    * Example: curl http://localhost:9000/shoppingcart/123
-    */
+   * Get a shopping cart.
+   *
+   * Example: curl http://localhost:9000/shoppingcart/123
+   */
   def get(id: String): ServiceCall[NotUsed, ShoppingCart]
 
   /**
@@ -36,25 +40,25 @@ trait ShoppingCartService extends Service {
   def getReport(id: String): ServiceCall[NotUsed, ShoppingCartReport]
 
   /**
-    * Update an items quantity in the shopping cart.
-    *
-    * Example: curl -H "Content-Type: application/json" -X POST -d '{"productId": 456, "quantity": 2}' http://localhost:9000/shoppingcart/123
-    */
+   * Update an items quantity in the shopping cart.
+   *
+   * Example: curl -H "Content-Type: application/json" -X POST -d '{"productId": 456, "quantity": 2}' http://localhost:9000/shoppingcart/123
+   */
   def updateItem(id: String): ServiceCall[ShoppingCartItem, Done]
 
   /**
-    * Checkout the shopping cart.
-    *
-    * Example: curl -X POST http://localhost:9000/shoppingcart/123/checkout
-    */
+   * Checkout the shopping cart.
+   *
+   * Example: curl -X POST http://localhost:9000/shoppingcart/123/checkout
+   */
   def checkout(id: String): ServiceCall[NotUsed, Done]
 
   /**
-    * This gets published to Kafka.
-    */
+   * This gets published to Kafka.
+   */
   def shoppingCartTopic: Topic[ShoppingCart]
 
-  override final def descriptor = {
+  final override def descriptor = {
     import Service._
     // @formatter:off
     named("shopping-cart")
@@ -82,29 +86,30 @@ trait ShoppingCartService extends Service {
 }
 
 /**
-  * A shopping cart item.
-  *
-  * @param productId The ID of the product.
-  * @param quantity The quantity of the product.
-  */
+ * A shopping cart item.
+ *
+ * @param productId The ID of the product.
+ * @param quantity The quantity of the product.
+ */
 case class ShoppingCartItem(productId: String, quantity: Int)
 
 object ShoppingCartItem {
+
   /**
-    * Format for converting the shopping cart item to and from JSON.
-    *
-    * This will be picked up by a Lagom implicit conversion from Play's JSON format to Lagom's message serializer.
-    */
+   * Format for converting the shopping cart item to and from JSON.
+   *
+   * This will be picked up by a Lagom implicit conversion from Play's JSON format to Lagom's message serializer.
+   */
   implicit val format: Format[ShoppingCartItem] = Json.format
 }
 
 /**
-  * A shopping cart.
-  *
-  * @param id The id of the shopping cart.
-  * @param items The items in the shopping cart.
-  * @param checkedOut Whether the shopping cart has been checked out (submitted).
-  */
+ * A shopping cart.
+ *
+ * @param id The id of the shopping cart.
+ * @param items The items in the shopping cart.
+ * @param checkedOut Whether the shopping cart has been checked out (submitted).
+ */
 case class ShoppingCart(id: String, items: Seq[ShoppingCartItem], checkedOut: Boolean)
 
 object ShoppingCart {
@@ -112,15 +117,11 @@ object ShoppingCart {
   implicit val format: Format[ShoppingCart] = Json.format
 }
 
-
 /**
  * A shopping cart report exposes information about a ShoppingCart.
  */
-case class ShoppingCartReport(cartId: String,
-                              creationDate: Instant,
-                              checkoutDate: Option[Instant])
+case class ShoppingCartReport(cartId: String, creationDate: Instant, checkoutDate: Option[Instant])
 
 object ShoppingCartReport {
   implicit val format: Format[ShoppingCartReport] = Json.format
 }
-

--- a/shopping-cart/shopping-cart-scala/shopping-cart/src/main/resources/application.conf
+++ b/shopping-cart/shopping-cart-scala/shopping-cart/src/main/resources/application.conf
@@ -27,3 +27,13 @@ akka.actor.serialization-bindings {
   "akka.actor.Address"        = akka-misc
   "akka.remote.UniqueAddress" = akka-misc
 }
+
+
+akka.actor {
+
+  serialization-bindings {
+    # commands won't use play-json but Akka's jackson support
+    "com.example.shoppingcart.impl.ShoppingCartCommandSerializable"    = jackson-json
+  }
+
+}

--- a/shopping-cart/shopping-cart-scala/shopping-cart/src/main/scala/com/example/shoppingcart/impl/LagomTaggerAdapter.scala
+++ b/shopping-cart/shopping-cart-scala/shopping-cart/src/main/scala/com/example/shoppingcart/impl/LagomTaggerAdapter.scala
@@ -1,0 +1,25 @@
+package com.example.shoppingcart.impl
+
+import com.lightbend.lagom.scaladsl.persistence.AggregateEventTag
+import com.lightbend.lagom.scaladsl.persistence.AggregateEventTagger
+import com.lightbend.lagom.scaladsl.persistence.AggregateEventShards
+import com.lightbend.lagom.scaladsl.persistence.AggregateEvent
+import akka.cluster.sharding.typed.scaladsl.EntityContext
+
+object LagomTaggerAdapter {
+
+  
+  def apply[Event <: AggregateEvent[Event]](
+      entityCtx: EntityContext,
+      lagomTagger: AggregateEventTagger[Event]
+  ): Event => Set[String] = { evt =>
+    val tag =
+      lagomTagger match {
+        case tagger: AggregateEventTag[_] =>
+          tagger.tag
+        case shardedTagger: AggregateEventShards[_] =>
+          shardedTagger.forEntityId(entityCtx.entityId).tag
+      }
+    Set(tag)
+  }
+}

--- a/shopping-cart/shopping-cart-scala/shopping-cart/src/main/scala/com/example/shoppingcart/impl/ShoppingCartEntity.scala
+++ b/shopping-cart/shopping-cart-scala/shopping-cart/src/main/scala/com/example/shoppingcart/impl/ShoppingCartEntity.scala
@@ -1,210 +1,149 @@
 package com.example.shoppingcart.impl
 
-import java.time.{Instant, OffsetDateTime}
-
 import akka.Done
-import com.lightbend.lagom.scaladsl.persistence.{AggregateEvent, AggregateEventTag, PersistentEntity}
-import com.lightbend.lagom.scaladsl.persistence.PersistentEntity.ReplyType
-import com.lightbend.lagom.scaladsl.playjson.{JsonSerializer, JsonSerializerRegistry}
+import akka.actor.typed.ActorRef
+import akka.actor.typed.ActorSystem
+import akka.actor.typed.Behavior
+import akka.cluster.sharding.typed.scaladsl._
+import akka.persistence.journal.Tagged
+import akka.persistence.typed.ExpectingReply
+import akka.persistence.typed.PersistenceId
+import akka.persistence.typed.scaladsl.Effect
+import akka.persistence.typed.scaladsl.EventSourcedBehavior
+import akka.persistence.typed.scaladsl.ReplyEffect
+import com.lightbend.lagom.scaladsl.persistence.AggregateEvent
+import com.lightbend.lagom.scaladsl.persistence.AggregateEventShards
+import com.lightbend.lagom.scaladsl.persistence.AggregateEventTag
+import com.lightbend.lagom.scaladsl.playjson.JsonSerializer
+import com.lightbend.lagom.scaladsl.playjson.JsonSerializerRegistry
+import play.api.libs.json.Format
 import play.api.libs.json._
 
 import scala.collection.immutable.Seq
+import java.time.Instant
 
 /**
-  * This is an event sourced entity. It has a state,
-  * [[com.example.shoppingcart.impl.ShoppingCartState]], which stores the
-  * current shopping cart items and whether it's checked out.
-  *
-  * Event sourced entities are interacted with by sending them commands. This
-  * entity supports three commands, an
-  * [[com.example.shoppingcart.impl.UpdateItem]] command, which is used to
-  * update the quantity of an item in the cart, a
-  * [[com.example.shoppingcart.impl.Checkout]] command which is used to set
-  * checkout the shopping cart, and a [[com.example.shoppingcart.impl.Get]]
-  * command, which is a read only command which returns the current shopping
-  * cart state.
-  *
-  * Commands get translated to events, and it's the events that get persisted
-  * by the entity. Each event will have an event handler registered for it, and
-  * an event handler simply applies an event to the current state. This will be
-  * done when the event is first created, and it will also be done when the
-  * entity is loaded from the database - each event will be replayed to
-  * recreate the state of the entity.
-  *
-  * This entity defines two events, the
-  * [[com.example.shoppingcart.impl.ItemUpdated]] event, which is emitted when
-  * a [[com.example.shoppingcart.impl.UpdateItem]] command is received, and a
-  * [[com.example.shoppingcart.impl.CheckedOut]] event, which is emitted when a
-  * [[com.example.shoppingcart.impl.Checkout]] command is received.
-  */
-class ShoppingCartEntity extends PersistentEntity {
-
-  import play.api.libs.functional.syntax._
-  def naStringSerializer: Format[Option[String]] =
-    implicitly[Format[String]].inmap(
-      str => Some(str).filterNot(_ == "N/A"),
-      maybeStr => maybeStr.getOrElse("N/A")
-    )
-
-  override type Command = ShoppingCartCommand[_]
-  override type Event = ShoppingCartEvent
-  override type State = ShoppingCartState
-
-  /**
-    * The initial state. This is used if there is no snapshotted state to be found.
-    */
-  override def initialState: ShoppingCartState = ShoppingCartState(Map.empty, checkedOut = false)
-
-  /**
-    * An entity can define different behaviours for different states, so the behaviour
-    * is a function of the current state to a set of actions.
-    */
-  override def behavior: Behavior = {
-    case ShoppingCartState(_, false) => openShoppingCart
-    case ShoppingCartState(_, true) => checkedOut
-  }
-
-  def openShoppingCart = {
-    Actions().onCommand[UpdateItem, Done] {
-
-      // Command handler for the UpdateItem command
-      case (UpdateItem(_, quantity), ctx, _) if quantity < 0 =>
-        ctx.commandFailed(ShoppingCartException("Quantity must be greater than zero"))
-        ctx.done
-      case (UpdateItem(productId, 0), ctx, state) if !state.items.contains(productId) =>
-        ctx.commandFailed(ShoppingCartException("Cannot delete item that is not already in cart"))
-        ctx.done
-      case (UpdateItem(productId, quantity), ctx, _) =>
-        // In response to this command, we want to first persist it as a
-        // ItemUpdated event
-        ctx.thenPersist(
-          ItemUpdated(productId, quantity, Instant.now())
-        ) { _ =>
-          // Then once the event is successfully persisted, we respond with done.
-          ctx.reply(Done)
-        }
-
-    }.onCommand[Checkout.type, Done] {
-
-      // Command handler for the Checkout command
-      case (Checkout, ctx, state) if state.items.isEmpty =>
-        ctx.commandFailed(ShoppingCartException("Cannot checkout empty cart"))
-        ctx.done
-      case (Checkout, ctx, _) =>
-        // In response to this command, we want to first persist it as a
-        // CheckedOut event
-        ctx.thenPersist(
-          CheckedOut(Instant.now())
-        ) { _ =>
-          // Then once the event is successfully persisted, we respond with done.
-          ctx.reply(Done)
-        }
-
-    }.onReadOnlyCommand[Get.type, ShoppingCartState] {
-
-      // Command handler for the Hello command
-      case (Get, ctx, state) =>
-        // Reply with the current state.
-        ctx.reply(state)
-
-    }.onEvent(eventHandlers)
-  }
-
-  def checkedOut = {
-    Actions().onReadOnlyCommand[Get.type, ShoppingCartState] {
-
-      // Command handler for the Hello command
-      case (Get, ctx, state) =>
-        // Reply with the current state.
-        ctx.reply(state)
-
-    }.onCommand[UpdateItem, Done] {
-
-      // Not valid when checked out
-      case (_, ctx, _) =>
-        ctx.commandFailed(ShoppingCartException("Can't update item on already checked out shopping cart"))
-        ctx.done
-
-    }.onCommand[Checkout.type, Done] {
-
-      // Not valid when checked out
-      case (_, ctx, _) =>
-        ctx.commandFailed(ShoppingCartException("Can't checkout on already checked out shopping cart"))
-        ctx.done
-
-    }.onEvent(eventHandlers)
-  }
-
-  def eventHandlers: EventHandler = {
-    // Event handler for the ItemUpdated event
-    case (ItemUpdated(productId: String, quantity: Int, _), state) => state.updateItem(productId, quantity)
-
-    // Event handler for the checkout event
-    case (_: CheckedOut, state) => state.checkout
-  }
-}
-
-/**
-  * The current state held by the persistent entity.
-  */
+ * The current state held by the persistent entity.
+ */
 case class ShoppingCartState(items: Map[String, Int], checkedOut: Boolean) {
 
-  def updateItem(productId: String, quantity: Int) = {
+  def applyCommand(cmd: ShoppingCartCommand[_]): ReplyEffect[ShoppingCartEvent, ShoppingCartState] =
+    cmd match {
+      case x: UpdateItem => onUpdateItem(x)
+      case x: Checkout   => onCheckout(x)
+      case x: Get        => onReadState(x)
+    }
+
+  def onUpdateItem(cmd: UpdateItem): ReplyEffect[ShoppingCartEvent, ShoppingCartState] =
+    cmd match {
+      case UpdateItem(_, qty, _) if qty < 0 =>
+        Effect.reply(cmd)(Rejected("Quantity must be greater than zero"))
+
+      case UpdateItem(productId, 0, _) if !items.contains(productId) =>
+        Effect.reply(cmd)(Rejected("Cannot delete item that is not already in cart"))
+
+      case UpdateItem(productId, quantity, _) =>
+        Effect
+          .persist(ItemUpdated(productId, quantity, Instant.now()))
+          .thenReply(cmd) { _ =>
+            Accepted
+          }
+    }
+
+  def onCheckout(cmd: Checkout): ReplyEffect[ShoppingCartEvent, ShoppingCartState] =
+    if (items.isEmpty)
+      Effect.reply(cmd)(Rejected("Cannot checkout empty cart"))
+    else
+      Effect
+        .persist(CheckedOut(Instant.now()))
+        .thenReply(cmd) { _ =>
+          Accepted
+        }
+
+  def onReadState(cmd: Get): ReplyEffect[ShoppingCartEvent, ShoppingCartState] =
+    Effect.reply(cmd)(CurrentState(this))
+
+  def applyEvent(evt: ShoppingCartEvent): ShoppingCartState = {
+    evt match {
+      case ItemUpdated(productId, quantity, _) => updateItem(productId, quantity)
+      case CheckedOut(_)                       => checkout
+    }
+  }
+
+  private def updateItem(productId: String, quantity: Int) = {
     quantity match {
       case 0 => copy(items = items - productId)
       case _ => copy(items = items + (productId -> quantity))
     }
   }
 
-  def checkout = copy(checkedOut = true)
+  private def checkout = copy(checkedOut = true)
 }
 
 object ShoppingCartState {
+
+  def empty: ShoppingCartState = ShoppingCartState(Map.empty, checkedOut = false)
+
+  val typeKey = EntityTypeKey[ShoppingCartCommand[_]]("ShoppingCartEntity")
+
+  def behavior(entityContext: EntityContext): Behavior[ShoppingCartCommand[_]] = {
+
+    val persistenceId = typeKey.persistenceIdFrom(entityContext.entityId)
+
+    EventSourcedBehavior
+      .withEnforcedReplies[ShoppingCartCommand[_], ShoppingCartEvent, ShoppingCartState](
+        persistenceId = persistenceId,
+        emptyState = ShoppingCartState.empty,
+        commandHandler = (cart, cmd) => cart.applyCommand(cmd),
+        eventHandler = (cart, evt) => cart.applyEvent(evt)
+      )
+      .withTagger(LagomTaggerAdapter(entityContext, ShoppingCartEvent.Tag))
+
+  }
+
   /**
-    * Format for the hello state.
-    *
-    * Persisted entities get snapshotted every configured number of events. This
-    * means the state gets stored to the database, so that when the entity gets
-    * loaded, you don't need to replay all the events, just the ones since the
-    * snapshot. Hence, a JSON format needs to be declared so that it can be
-    * serialized and deserialized when storing to and from the database.
-    */
+   * Format for the hello state.
+   *
+   * Persisted entities get snapshotted every configured number of events. This
+   * means the state gets stored to the database, so that when the entity gets
+   * loaded, you don't need to replay all the events, just the ones since the
+   * snapshot. Hence, a JSON format needs to be declared so that it can be
+   * serialized and deserialized when storing to and from the database.
+   */
   implicit val format: Format[ShoppingCartState] = Json.format
 }
 
 /**
-  * This interface defines all the events that the ShoppingCartEntity supports.
-  */
+ * This interface defines all the events that the ShoppingCartEntity supports.
+ */
 sealed trait ShoppingCartEvent extends AggregateEvent[ShoppingCartEvent] {
   def aggregateTag = ShoppingCartEvent.Tag
 }
 
 object ShoppingCartEvent {
-  val Tag = AggregateEventTag[ShoppingCartEvent]
+  val Tag = AggregateEventTag.sharded[ShoppingCartEvent](numShards = 10)
 }
 
 /**
-  * An event that represents a item updated event.
-  */
-case class ItemUpdated(productId: String, quantity: Int, eventTime: Instant) extends ShoppingCartEvent
+ * An event that represents a item updated event.
+ */
+final case class ItemUpdated(productId: String, quantity: Int, eventTime: Instant) extends ShoppingCartEvent
 
 object ItemUpdated {
 
   /**
-    * Format for the item updated event.
-    *
-    * Events get stored and loaded from the database, hence a JSON format
-    * needs to be declared so that they can be serialized and deserialized.
-    */
+   * Format for the item updated event.
+   *
+   * Events get stored and loaded from the database, hence a JSON format
+   * needs to be declared so that they can be serialized and deserialized.
+   */
   implicit val format: Format[ItemUpdated] = Json.format
 }
 
-/**
-  * An event that represents a checked out event.
-  */
-case class CheckedOut(eventTime: Instant) extends ShoppingCartEvent
+final case class CheckedOut(eventTime: Instant) extends ShoppingCartEvent
 
 object CheckedOut {
+
   /**
    * Format for the checked out event.
    *
@@ -214,114 +153,126 @@ object CheckedOut {
   implicit val format: Format[CheckedOut] = Json.format
 }
 
-/**
-  * This interface defines all the commands that the ShoppingCartEntity supports.
-  */
-sealed trait ShoppingCartCommand[R] extends ReplyType[R]
+sealed trait ShoppingCartReply
 
-/**
-  * A command to update an item.
-  *
-  * It has a reply type of `Done`, which is sent back to the caller when
-  * all the events emitted by this command are successfully persisted.
-  */
-case class UpdateItem(productId: String, quantity: Int) extends ShoppingCartCommand[Done]
+object ShoppingCartReply {
+  implicit val format: Format[ShoppingCartReply] =
+    new Format[ShoppingCartReply] {
 
-object UpdateItem {
+      override def reads(json: JsValue): JsResult[ShoppingCartReply] = {
+        if ((json \ "state").isDefined)
+          Json.fromJson[CurrentState](json)
+        else
+          Json.fromJson[Confirmation](json)
+      }
 
-  /**
-    * Format for the update item command.
-    *
-    * Persistent entities get sharded across the cluster. This means commands
-    * may be sent over the network to the node where the entity lives if the
-    * entity is not on the same node that the command was issued from. To do
-    * that, a JSON format needs to be declared so the command can be serialized
-    * and deserialized.
-    */
-  implicit val format: Format[UpdateItem] = Json.format
+      override def writes(o: ShoppingCartReply): JsValue = {
+        o match {
+          case conf: Confirmation  => Json.toJson(conf)
+          case state: CurrentState => Json.toJson(state)
+        }
+      }
+    }
 }
 
-/**
-  * A command to get the current state of the shopping cart.
-  *
-  * The reply type is the ShoppingCart, and will contain the message to say to that
-  * person.
-  */
-case object Get extends ShoppingCartCommand[ShoppingCartState] {
+sealed trait Confirmation extends ShoppingCartReply
 
-  /**
-    * Format for the Get command.
-    *
-    * Persistent entities get sharded across the cluster. This means commands
-    * may be sent over the network to the node where the entity lives if the
-    * entity is not on the same node that the command was issued from. To do
-    * that, a JSON format needs to be declared so the command can be serialized
-    * and deserialized.
-    */
-  implicit val format: Format[Get.type] = Format(
-    Reads(_ => JsSuccess(Get)),
+case object Confirmation {
+  implicit val format: Format[Confirmation] = new Format[Confirmation] {
+    override def reads(json: JsValue): JsResult[Confirmation] = {
+      if ((json \ "reason").isDefined)
+        Json.fromJson[Rejected](json)
+      else
+        Json.fromJson[Accepted](json)
+    }
+
+    override def writes(o: Confirmation): JsValue = {
+      o match {
+        case acc: Accepted => Json.toJson(acc)
+        case rej: Rejected => Json.toJson(rej)
+      }
+    }
+  }
+}
+
+sealed trait Accepted extends Confirmation
+
+case object Accepted extends Accepted {
+  implicit val format: Format[Accepted] = Format(
+    Reads(_ => JsSuccess(Accepted)),
     Writes(_ => Json.obj())
   )
 }
 
-/**
-  * A command to checkout the shopping cart.
-  *
-  * The reply type is the Done, which will be returned when the events have been
-  * emitted.
-  */
-case object Checkout extends ShoppingCartCommand[Done] {
+case class Rejected(reason: String) extends Confirmation
 
-  /**
-    * Format for the Checkout command.
-    *
-    * Persistent entities get sharded across the cluster. This means commands
-    * may be sent over the network to the node where the entity lives if the
-    * entity is not on the same node that the command was issued from. To do
-    * that, a JSON format needs to be declared so the command can be serialized
-    * and deserialized.
-    */
-  implicit val format: Format[Checkout.type] = Format(
-    Reads(_ => JsSuccess(Checkout)),
-    Writes(_ => Json.obj())
-  )
+object Rejected {
+  implicit val format: Format[Rejected] = Json.format
+}
+
+final case class CurrentState(state: ShoppingCartState) extends ShoppingCartReply
+
+object CurrentState {
+  implicit val format: Format[CurrentState] = Json.format
 }
 
 /**
-  * An exception thrown by the shopping cart validation
-  *
-  * @param message The message
-  */
-case class ShoppingCartException(message: String) extends RuntimeException(message)
-
-object ShoppingCartException {
-
-  /**
-    * Format for the ShoppingCartException.
-    *
-    * When a command fails, the error needs to be serialized and sent back to
-    * the node that requested it, this is used to do that.
-    */
-  implicit val format: Format[ShoppingCartException] = Json.format[ShoppingCartException]
-}
+ * This is a marker trait for shopping cart commands.
+ * We will serialize them using Akka's Jackson support that is able to deal with the replyTo field.
+ * (see application.conf)
+ */
+trait ShoppingCartCommandSerializable
 
 /**
-  * Akka serialization, used by both persistence and remoting, needs to have
-  * serializers registered for every type serialized or deserialized. While it's
-  * possible to use any serializer you want for Akka messages, out of the box
-  * Lagom provides support for JSON, via this registry abstraction.
-  *
-  * The serializers are registered here, and then provided to Lagom in the
-  * application loader.
-  */
+ * This interface defines all the commands that the ShoppingCartEntity supports.
+ */
+sealed trait ShoppingCartCommand[R <: ShoppingCartReply] extends ExpectingReply[R] with ShoppingCartCommandSerializable
+
+/**
+ * A command to update an item.
+ *
+ * It has a reply type of [[Done]], which is sent back to the caller
+ * when all the events emitted by this command are successfully persisted.
+ */
+case class UpdateItem(productId: String, quantity: Int, replyTo: ActorRef[Confirmation])
+    extends ShoppingCartCommand[Confirmation]
+
+/**
+ * A command to get the current state of the shopping cart.
+ *
+ * The reply type is the ShoppingCart, and will contain the message to say to that
+ * person.
+ */
+case class Get(replyTo: ActorRef[CurrentState]) extends ShoppingCartCommand[CurrentState]
+
+/**
+ * A command to checkout the shopping cart.
+ *
+ * The reply type is the Done, which will be returned when the events have been
+ * emitted.
+ */
+case class Checkout(replyTo: ActorRef[Confirmation]) extends ShoppingCartCommand[Confirmation]
+
+/**
+ * Akka serialization, used by both persistence and remoting, needs to have
+ * serializers registered for every type serialized or deserialized. While it's
+ * possible to use any serializer you want for Akka messages, out of the box
+ * Lagom provides support for JSON, via this registry abstraction.
+ *
+ * The serializers are registered here, and then provided to Lagom in the
+ * application loader.
+ */
 object ShoppingCartSerializerRegistry extends JsonSerializerRegistry {
   override def serializers: Seq[JsonSerializer[_]] = Seq(
+    // state and events can use play-json, but commands should use jackson because of ActorRef[T] (see application.conf)
+    JsonSerializer[ShoppingCartState],
     JsonSerializer[ItemUpdated],
     JsonSerializer[CheckedOut],
-    JsonSerializer[UpdateItem],
-    JsonSerializer[Checkout.type],
-    JsonSerializer[Get.type],
-    JsonSerializer[ShoppingCartState],
-    JsonSerializer[ShoppingCartException]
+    // the replies use play-json as well
+    JsonSerializer[ShoppingCartReply],
+    JsonSerializer[CurrentState],
+    JsonSerializer[Confirmation],
+    JsonSerializer[Accepted],
+    JsonSerializer[Rejected]
   )
 }

--- a/shopping-cart/shopping-cart-scala/shopping-cart/src/main/scala/com/example/shoppingcart/impl/ShoppingCartReportProcessor.scala
+++ b/shopping-cart/shopping-cart-scala/shopping-cart/src/main/scala/com/example/shoppingcart/impl/ShoppingCartReportProcessor.scala
@@ -3,9 +3,8 @@ package com.example.shoppingcart.impl
 import com.lightbend.lagom.scaladsl.persistence.ReadSideProcessor
 import com.lightbend.lagom.scaladsl.persistence.slick.SlickReadSide
 
-
-class ShoppingCartReportProcessor(readSide: SlickReadSide,
-                                  repository: ShoppingCartReportRepository) extends ReadSideProcessor[ShoppingCartEvent] {
+class ShoppingCartReportProcessor(readSide: SlickReadSide, repository: ShoppingCartReportRepository)
+    extends ReadSideProcessor[ShoppingCartEvent] {
 
   override def buildHandler() =
     readSide
@@ -19,5 +18,5 @@ class ShoppingCartReportProcessor(readSide: SlickReadSide,
       }
       .build()
 
-  override def aggregateTags = Set(ShoppingCartEvent.Tag)
+  override def aggregateTags = ShoppingCartEvent.Tag.allTags
 }

--- a/shopping-cart/shopping-cart-scala/shopping-cart/src/main/scala/com/example/shoppingcart/impl/ShoppingCartServiceImpl.scala
+++ b/shopping-cart/shopping-cart-scala/shopping-cart/src/main/scala/com/example/shoppingcart/impl/ShoppingCartServiceImpl.scala
@@ -2,68 +2,94 @@ package com.example.shoppingcart.impl
 
 import java.time.OffsetDateTime
 
-import akka.{Done, NotUsed}
-import com.example.shoppingcart.api.{ShoppingCart, ShoppingCartItem, ShoppingCartReport, ShoppingCartService}
+import akka.Done
+import akka.NotUsed
+import com.example.shoppingcart.api.ShoppingCart
+import com.example.shoppingcart.api.ShoppingCartItem
+import com.example.shoppingcart.api.ShoppingCartReport
+import com.example.shoppingcart.api.ShoppingCartService
 import com.lightbend.lagom.scaladsl.api.ServiceCall
 import com.lightbend.lagom.scaladsl.api.broker.Topic
-import com.lightbend.lagom.scaladsl.api.transport.{BadRequest, NotFound, TransportException}
+import com.lightbend.lagom.scaladsl.api.transport.BadRequest
+import com.lightbend.lagom.scaladsl.api.transport.NotFound
+import com.lightbend.lagom.scaladsl.api.transport.TransportException
 import com.lightbend.lagom.scaladsl.broker.TopicProducer
-import com.lightbend.lagom.scaladsl.persistence.{EventStreamElement, PersistentEntityRegistry}
+import com.lightbend.lagom.scaladsl.persistence.EventStreamElement
+import com.lightbend.lagom.scaladsl.persistence.PersistentEntityRegistry
 
 import scala.concurrent.ExecutionContext
+import akka.cluster.sharding.typed.scaladsl.ClusterSharding
+import scala.concurrent.duration._
+import akka.util.Timeout
+import akka.cluster.sharding.typed.scaladsl.EntityRef
 
 /**
-  * Implementation of the `ShoppingCartService`.
-  */
-class ShoppingCartServiceImpl(persistentEntityRegistry: PersistentEntityRegistry, reportRepository: ShoppingCartReportRepository)(implicit ec: ExecutionContext) extends ShoppingCartService {
+ * Implementation of the `ShoppingCartService`.
+ */
+class ShoppingCartServiceImpl(
+    clusterSharding: ClusterSharding,
+    persistentEntityRegistry: PersistentEntityRegistry,
+    reportRepository: ShoppingCartReportRepository
+)(implicit ec: ExecutionContext)
+    extends ShoppingCartService {
 
   /**
-    * Looks up the shopping cart entity for the given ID.
-    */
-  private def entityRef(id: String) =
-    persistentEntityRegistry.refFor[ShoppingCartEntity](id)
+   * Looks up the shopping cart entity for the given ID.
+   */
+  private def entityRef(id: String): EntityRef[ShoppingCartCommand[_]] =
+    clusterSharding.entityRefFor(ShoppingCartState.typeKey, id)
+
+  implicit val timeout = Timeout(5.seconds)
 
   override def get(id: String): ServiceCall[NotUsed, ShoppingCart] = ServiceCall { _ =>
     entityRef(id)
-      .ask(Get)
+      .ask(reply => Get(reply))
       .map(cart => convertShoppingCart(id, cart))
   }
 
   override def updateItem(id: String): ServiceCall[ShoppingCartItem, Done] = ServiceCall { update =>
     entityRef(id)
-      .ask(UpdateItem(update.productId, update.quantity))
-      .recover {
-        case ShoppingCartException(message) => throw BadRequest(message)
+      .ask(reply => UpdateItem(update.productId, update.quantity, reply))
+      .map {
+        case Accepted         => Done
+        case Rejected(reason) => throw BadRequest(reason)
       }
   }
 
   override def checkout(id: String): ServiceCall[NotUsed, Done] = ServiceCall { _ =>
     entityRef(id)
       .ask(Checkout)
-      .recover {
-        case ShoppingCartException(message) => throw BadRequest(message)
+      .map {
+        case Accepted         => Done
+        case Rejected(reason) => throw BadRequest(reason)
       }
   }
 
-  override def shoppingCartTopic: Topic[ShoppingCart] = TopicProducer.singleStreamWithOffset { fromOffset =>
-    persistentEntityRegistry.eventStream(ShoppingCartEvent.Tag, fromOffset)
-      .filter(_.event.isInstanceOf[CheckedOut])
-      .mapAsync(4) {
-        case EventStreamElement(id, _, offset) =>
-          entityRef(id)
-            .ask(Get)
-            .map(cart => convertShoppingCart(id, cart) -> offset)
-      }
-    }
+  override def shoppingCartTopic: Topic[ShoppingCart] = TopicProducer.taggedStreamWithOffset(ShoppingCartEvent.Tag) {
+    (tag, fromOffset) =>
+      persistentEntityRegistry
+        .eventStream(tag, fromOffset)
+        .filter(_.event.isInstanceOf[CheckedOut])
+        .mapAsync(4) {
+          case EventStreamElement(id, _, offset) =>
+            entityRef(id)
+              .ask(Get)
+              .map(cart => convertShoppingCart(id, cart) -> offset)
+        }
+  }
 
-  private def convertShoppingCart(id: String, cart: ShoppingCartState) = {
-    ShoppingCart(id, cart.items.map((ShoppingCartItem.apply _).tupled).toSeq, cart.checkedOut)
+  private def convertShoppingCart(id: String, cart: CurrentState) = {
+    ShoppingCart(
+      id,
+      cart.state.items.map((ShoppingCartItem.apply _).tupled).toSeq,
+      cart.state.checkedOut
+    )
   }
 
   override def getReport(cartId: String): ServiceCall[NotUsed, ShoppingCartReport] = ServiceCall { _ =>
     reportRepository.findById(cartId).map {
       case Some(cart) => cart
-      case None => throw NotFound(s"Couldn't find a shopping cart report for '$cartId'")
+      case None       => throw NotFound(s"Couldn't find a shopping cart report for $cartId")
     }
   }
 }

--- a/shopping-cart/shopping-cart-scala/shopping-cart/src/main/scala/lagom/cluster/sharding/typed/AkkaTypedClusterComponents.scala
+++ b/shopping-cart/shopping-cart-scala/shopping-cart/src/main/scala/lagom/cluster/sharding/typed/AkkaTypedClusterComponents.scala
@@ -1,0 +1,11 @@
+package lagom.cluster.sharding.typed
+
+import akka.actor.ActorSystem
+import akka.actor.typed.scaladsl.adapter._
+import akka.cluster.sharding.typed.scaladsl.ClusterSharding
+
+trait AkkaTypedClusterComponents {
+  def actorSystem: ActorSystem
+
+  lazy val clusterSharding: ClusterSharding = ClusterSharding(actorSystem.toTyped)
+}


### PR DESCRIPTION
This PR is not for immediate merge, but to illustrate the bits and bytes needed to port a Lagom app to Akka Persistence Typed. 

I few things need to be moved to Lagom of course. 

The best way to test this PR by hand is to first create run shopping-cart-scala using that other branch: https://github.com/lagom/lagom-samples/pull/96

Start the docker container and fill the app with some events. PR #96 will generate partitioned tags. 

Once the journal is filled with some events, you can stop the app and start it again using this branch instead.