### PR TITLE
gRPC samples bump to lagom 1.6.0-M6

### DIFF
--- a/grpc-example/grpc-example-java/build.sbt
+++ b/grpc-example/grpc-example-java/build.sbt
@@ -91,5 +91,10 @@ lagomUnmanagedServices in ThisBuild := Map("helloworld.GreeterService" -> s"http
 
 
 def common = Seq(
-  javacOptions in Compile := Seq("-g", "-encoding", "UTF-8", "-parameters", "-Xlint:unchecked", "-Xlint:deprecation", "-parameters", "-Werror")
+  javacOptions in Compile := Seq("-g", "-encoding", "UTF-8", "-parameters", "-Xlint:unchecked", "-Xlint:deprecation"
+    // Can't enable -Werror until:
+    //  - akka-grpc stops using `ActorMaterializer` on generated code
+    //  - protobuf uses `com.google.protobuf.Descriptors.FileDescriptor` on generated code.
+    //    , "-parameters", "-Werror"
+  )
 )

--- a/grpc-example/grpc-example-java/build.sbt
+++ b/grpc-example/grpc-example-java/build.sbt
@@ -12,6 +12,14 @@ scalaVersion in ThisBuild := "2.12.8"
 lagomServiceEnableSsl in ThisBuild := true
 val `hello-impl-HTTPS-port` = 11000
 
+val akkaHttpFamilyOverrides = Seq(
+  "akka-http-spray-json",
+  "akka-parsing",
+  "akka-http2-support",
+  "akka-http",
+  "akka-http-core",
+).map { name => "com.typesafe.akka" %% name % "10.1.10" }
+
 val lagomGrpcTestkit = "com.lightbend.play" %% "lagom-javadsl-grpc-testkit" % "0.7.0" % Test
 
 lazy val `lagom-java-grpc-example` = (project in file("."))
@@ -43,7 +51,10 @@ lazy val `hello-impl` = (project in file("hello-impl"))
   // the port and the use the value to add the entry on the Service Registry
   lagomServiceHttpsPort := `hello-impl-HTTPS-port`,
 
-  libraryDependencies ++= Seq(
+    dependencyOverrides ++= akkaHttpFamilyOverrides,
+
+
+      libraryDependencies ++= Seq(
     lagomJavadslTestKit,
     lagomLogback,
     lagomGrpcTestkit

--- a/grpc-example/grpc-example-java/project/plugins.sbt
+++ b/grpc-example/grpc-example-java/project/plugins.sbt
@@ -1,5 +1,5 @@
 // The Lagom plugin
-addSbtPlugin("com.lightbend.lagom" % "lagom-sbt-plugin" % "1.6.0-M5")
+addSbtPlugin("com.lightbend.lagom" % "lagom-sbt-plugin" % "1.6.0-M6")
 
 // Akka GRPC
 addSbtPlugin("com.lightbend.akka.grpc" %% "sbt-akka-grpc" % "0.6.0")

--- a/grpc-example/grpc-example-scala/build.sbt
+++ b/grpc-example/grpc-example-scala/build.sbt
@@ -14,13 +14,14 @@ val lagomGrpcTestkit = "com.lightbend.play" %% "lagom-scaladsl-grpc-testkit" % "
 lagomServiceEnableSsl in ThisBuild := true
 val `hello-impl-HTTPS-port` = 11000
 
+val akkaHttpFamilyOverrides = Seq(
+  "akka-http-spray-json",
+  "akka-parsing",
+  "akka-http2-support",
+  "akka-http",
+  "akka-http-core",
+).map { name => "com.typesafe.akka" %% name % "10.1.10" }
 
-// ALL SETTINGS HERE ARE TEMPORARY WORKAROUNDS FOR KNOWN ISSUES OR WIP
-def workaroundSettings: Seq[sbt.Setting[_]] = Seq(
-  // Lagom still can't register a service under the gRPC name so we hard-code 
-  // the port and use the value to add the entry on the Service Registry
-  lagomServiceHttpsPort := `hello-impl-HTTPS-port`
-)
 
 lazy val `lagom-scala-grpc-example` = (project in file("."))
   .aggregate(`hello-api`, `hello-impl`, `hello-proxy-api`, `hello-proxy-impl`)
@@ -43,8 +44,12 @@ lazy val `hello-impl` = (project in file("hello-impl"))
       ),
     akkaGrpcExtraGenerators in Compile += PlayScalaServerCodeGenerator,
   ).settings(
-    workaroundSettings:_*
-  ).settings(
+  // Lagom still can't register a service under the gRPC name so we hard-code
+  // the port and use the value to add the entry on the Service Registry
+  lagomServiceHttpsPort := `hello-impl-HTTPS-port`,
+  dependencyOverrides ++= akkaHttpFamilyOverrides
+
+).settings(
     libraryDependencies ++= Seq(
       lagomScaladslTestKit,
       macwire,

--- a/grpc-example/grpc-example-scala/project/plugins.sbt
+++ b/grpc-example/grpc-example-scala/project/plugins.sbt
@@ -1,4 +1,4 @@
 // The Lagom plugin
-addSbtPlugin("com.lightbend.lagom" % "lagom-sbt-plugin" % "1.5.3")
+addSbtPlugin("com.lightbend.lagom" % "lagom-sbt-plugin" % "1.6.0-M6")
 // Akka GRPC
 addSbtPlugin("com.lightbend.akka.grpc" %% "sbt-akka-grpc" % "0.6.0")


### PR DESCRIPTION
Bumping to Lagom `1.6.0-M6` surfaced multiple issues with the gRPC samples:

- - - - - - - - - - 
 
1. Lagom `1.6.0-M6` uses Akka `2.6.0-M8`. The changes introduced since Lagom `1.6.0-M5` include:

 - deprecation of `ActorMaterializer`
 - internal use of protobuf v3 in Akka

The above two changes cause a collection of new deprecation messages on the code generated both by internal gRPC and `akka-grpc` generators:

<details>
<summary>Warning Samples</summary>


[warn] /Users/ignasi/git/projects/lightbend/lagom/lagom-samples/grpc-example/grpc-example-java/hello-proxy-impl/target/scala-2.12/src_managed/main/example/myapp/helloworld/grpc/GreeterServiceClientPowerApi.java:14:1: akka.stream.ActorMaterializer in akka.stream has been deprecated
[warn] import akka.stream.ActorMaterializer;
[warn] /Users/ignasi/git/projects/lightbend/lagom/lagom-samples/grpc-example/grpc-example-java/hello-impl/target/scala-2.12/src_managed/main/example/myapp/helloworld/grpc/GreeterServiceClient.java:14:1: akka.stream.ActorMaterializer in akka.stream has been deprecated
[warn] import akka.stream.ActorMaterializer;
[warn] /Users/ignasi/git/projects/lightbend/lagom/lagom-samples/grpc-example/grpc-example-java/hello-impl/target/scala-2.12/src_managed/main/example/myapp/helloworld/grpc/GreeterServiceClientPowerApi.java:14:1: akka.stream.ActorMaterializer in akka.stream has been deprecated
[warn] import akka.stream.ActorMaterializer;
[warn] /Users/ignasi/git/projects/lightbend/lagom/lagom-samples/grpc-example/grpc-example-java/hello-proxy-impl/target/scala-2.12/src_managed/main/example/myapp/helloworld/grpc/GreeterServiceClient.java:55:1: akka.stream.ActorMaterializer in akka.stream has been deprecated
[warn]         if (mat instanceof ActorMaterializer) {
[warn] /Users/ignasi/git/projects/lightbend/lagom/lagom-samples/grpc-example/grpc-example-java/hello-proxy-impl/target/scala-2.12/src_managed/main/example/myapp/helloworld/grpc/GreeterServiceClient.java:56:1: akka.stream.ActorMaterializer in akka.stream has been deprecated
[warn]           ((ActorMaterializer) mat).system().getWhenTerminated().whenComplete((v, e) -> close());
[warn] /Users/ignasi/git/projects/lightbend/lagom/lagom-samples/grpc-example/grpc-example-java/hello-impl/target/scala-2.12/src_managed/main/example/myapp/helloworld/grpc/GreeterServiceClient.java:55:1: akka.stream.ActorMaterializer in akka.stream has been deprecated
[warn]         if (mat instanceof ActorMaterializer) {
[warn] /Users/ignasi/git/projects/lightbend/lagom/lagom-samples/grpc-example/grpc-example-java/hello-impl/target/scala-2.12/src_managed/main/example/myapp/helloworld/grpc/GreeterServiceClient.java:56:1: akka.stream.ActorMaterializer in akka.stream has been deprecated
[warn]           ((ActorMaterializer) mat).system().getWhenTerminated().whenComplete((v, e) -> close());
[warn] /Users/ignasi/git/projects/lightbend/lagom/lagom-samples/grpc-example/grpc-example-java/hello-impl/target/scala-2.12/src_managed/main/example/myapp/helloworld/grpc/HelloWorldProto.java:43:1: com.google.protobuf.Descriptors.FileDescriptor.InternalDescriptorAssigner in com.google.protobuf.Descriptors.FileDescriptor has been deprecated
[warn]     com.google.protobuf.Descriptors.FileDescriptor.InternalDescriptorAssigner assigner =
[warn] /Users/ignasi/git/projects/lightbend/lagom/lagom-samples/grpc-example/grpc-example-java/hello-impl/target/scala-2.12/src_managed/main/example/myapp/helloworld/grpc/HelloWorldProto.java:44:1: com.google.protobuf.Descriptors.FileDescriptor.InternalDescriptorAssigner in com.google.protobuf.Descriptors.FileDescriptor has been deprecated
[warn]         new com.google.protobuf.Descriptors.FileDescriptor.    InternalDescriptorAssigner() {
[warn] /Users/ignasi/git/projects/lightbend/lagom/lagom-samples/grpc-example/grpc-example-java/hello-impl/target/scala-2.12/src_managed/main/example/myapp/helloworld/grpc/HelloWorldProto.java:52:1: internalBuildGeneratedFileFrom(java.lang.String[],com.google.protobuf.Descriptors.FileDescriptor[],com.google.protobuf.Descriptors.FileDescriptor.InternalDescriptorAssigner) in com.google.protobuf.Descriptors.FileDescriptor has been deprecated
[warn]       .internalBuildGeneratedFileFrom(descriptorData,
[warn] /Users/ignasi/git/projects/lightbend/lagom/lagom-samples/grpc-example/grpc-example-java/hello-proxy-impl/target/scala-2.12/src_managed/main/example/myapp/helloworld/grpc/HelloWorldProto.java:43:1: com.google.protobuf.Descriptors.FileDescriptor.InternalDescriptorAssigner in com.google.protobuf.Descriptors.FileDescriptor has been deprecated
[warn]     com.google.protobuf.Descriptors.FileDescriptor.InternalDescriptorAssigner assigner =
[warn] /Users/ignasi/git/projects/lightbend/lagom/lagom-samples/grpc-example/grpc-example-java/hello-proxy-impl/target/scala-2.12/src_managed/main/example/myapp/helloworld/grpc/HelloWorldProto.java:44:1: com.google.protobuf.Descriptors.FileDescriptor.InternalDescriptorAssigner in com.google.protobuf.Descriptors.FileDescriptor has been deprecated
[warn]         new com.google.protobuf.Descriptors.FileDescriptor.    InternalDescriptorAssigner() {
[warn] /Users/ignasi/git/projects/lightbend/lagom/lagom-samples/grpc-example/grpc-example-java/hello-proxy-impl/target/scala-2.12/src_managed/main/example/myapp/helloworld/grpc/HelloWorldProto.java:52:1: internalBuildGeneratedFileFrom(java.lang.String[],com.google.protobuf.Descriptors.FileDescriptor[],com.google.protobuf.Descriptors.FileDescriptor.InternalDescriptorAssigner) in com.google.protobuf.Descriptors.FileDescriptor has been deprecated
[warn]       .internalBuildGeneratedFileFrom(descriptorData,

</details>

Until fixed upstream (or here?), we need to disable `-Werror` on this sample.

related https://github.com/playframework/play-grpc/pull/150

related https://github.com/akka/akka-grpc/pull/694

- - - - - - - - - - 

2. The dependencies on the `akka-http` family are mixed up between `10.1.9` and `10.1.10` versions:

```
[info] com.typesafe.akka:akka-http2-support_2.12:10.1.9 [S]
[info]   +-com.lightbend.akka.grpc:akka-grpc-runtime_2.12:0.6.0 [S]
[info]   | +-com.example:hello-impl_2.12:1.0-SNAPSHOT [S]
[info]   |
[info]   +-com.typesafe.play:play-akka-http2-support_2.12:2.8.0-M5 [S]
[info]     +-com.example:hello-impl_2.12:1.0-SNAPSHOT [S]
[info]
```