### PR TITLE
Align Java and Scala gRPC examples

### DIFF
--- a/grpc-example/grpc-example-java/project/plugins.sbt
+++ b/grpc-example/grpc-example-java/project/plugins.sbt
@@ -3,7 +3,3 @@ addSbtPlugin("com.lightbend.lagom" % "lagom-sbt-plugin" % "1.6.0-M5")
 
 // Akka GRPC
 addSbtPlugin("com.lightbend.akka.grpc" %% "sbt-akka-grpc" % "0.6.0")
-resolvers ++= Seq(          // for the snapshot ^
-  Resolver.bintrayIvyRepo("akka", "sbt-plugin-releases"),
-  Resolver.bintrayRepo("akka", "maven"),
-)

--- a/grpc-example/grpc-example-scala/project/plugins.sbt
+++ b/grpc-example/grpc-example-scala/project/plugins.sbt
@@ -1,4 +1,5 @@
 // The Lagom plugin
-addSbtPlugin("com.lightbend.lagom" % "lagom-sbt-plugin" % "1.5.3")
+addSbtPlugin("com.lightbend.lagom" % "lagom-sbt-plugin" % "1.6.0-M5")
+
 // Akka GRPC
 addSbtPlugin("com.lightbend.akka.grpc" %% "sbt-akka-grpc" % "0.6.0")


### PR DESCRIPTION
- Update Scala to Lagom 1.6.0-M5
- Remove the extra resolvers from Java