### PR TITLE
Remove extra serialization bindings

### DIFF
--- a/couchbase-persistence/couchbase-persistence-java-mvn/hello-impl/src/main/resources/application.conf
+++ b/couchbase-persistence/couchbase-persistence-java-mvn/hello-impl/src/main/resources/application.conf
@@ -2,12 +2,6 @@ play.modules.enabled += com.lightbend.lagom.sampleshello.impl.HelloModule
 
 lagom.persistence.ask-timeout = 10s
 akka.cluster.sharding.state-store-mode = ddata
-akka.actor.serialization-bindings {
-  "akka.Done" = akka-misc
-  "akka.actor.Address" = akka-misc
-  "akka.remote.UniqueAddress" = akka-misc
-}
-
 
 //#couchbase-begin
 hello.couchbase.bucket = "akka"

--- a/couchbase-persistence/couchbase-persistence-scala-sbt/hello-impl/src/main/resources/application.conf
+++ b/couchbase-persistence/couchbase-persistence-scala-sbt/hello-impl/src/main/resources/application.conf
@@ -2,12 +2,6 @@ play.application.loader = com.lightbend.lagom.sampleshello.impl.HelloLoader
 play.allowGlobalApplication = true
 
 akka.cluster.sharding.state-store-mode = ddata
-akka.actor.serialization-bindings {
-  "akka.Done" = akka-misc
-  "akka.actor.Address" = akka-misc
-  "akka.remote.UniqueAddress" = akka-misc
-}
-
 
 //#couchbase-begin
 hello.couchbase.bucket = "akka"

--- a/shopping-cart/shopping-cart-java/shopping-cart/src/main/resources/application.conf
+++ b/shopping-cart/shopping-cart-java/shopping-cart/src/main/resources/application.conf
@@ -16,12 +16,3 @@ jdbc-defaults.slick.profile = "slick.jdbc.PostgresProfile$"
 # Prefer 'ddata' over 'persistence' to share cluster sharding state for new projects.
 # See https://doc.akka.io/docs/akka/current/cluster-sharding.html#distributed-data-vs-persistence-mode
 akka.cluster.sharding.state-store-mode = ddata
-
-# Enable the serializer provided in Akka 2.5.8+ for akka.Done and other internal
-# messages to avoid the use of Java serialization.
-akka.actor.serialization-bindings {
-  "akka.Done"                 = akka-misc
-  "akka.NotUsed"              = akka-misc
-  "akka.actor.Address"        = akka-misc
-  "akka.remote.UniqueAddress" = akka-misc
-}

--- a/shopping-cart/shopping-cart-scala/shopping-cart/src/main/resources/application.conf
+++ b/shopping-cart/shopping-cart-scala/shopping-cart/src/main/resources/application.conf
@@ -18,12 +18,3 @@ jdbc-defaults.slick.profile = "slick.jdbc.PostgresProfile$"
 # Prefer 'ddata' over 'persistence' to share cluster sharding state for new projects.
 # See https://doc.akka.io/docs/akka/current/cluster-sharding.html#distributed-data-vs-persistence-mode
 akka.cluster.sharding.state-store-mode = ddata
-
-# Enable the serializer provided in Akka 2.5.8+ for akka.Done and other internal
-# messages to avoid the use of Java serialization.
-akka.actor.serialization-bindings {
-  "akka.Done"                 = akka-misc
-  "akka.NotUsed"              = akka-misc
-  "akka.actor.Address"        = akka-misc
-  "akka.remote.UniqueAddress" = akka-misc
-}


### PR DESCRIPTION
These are configured by default in Lagom 1.5.3+.

Ref:
- https://github.com/lagom/lagom/pull/1922
- https://github.com/lagom/lagom-java.g8/pull/66
- https://github.com/lagom/lagom-scala.g8/pull/66

Thanks to @lightwave for pointing this out in Gitter.