### PR TITLE
Revert "Remove log capturing"

### DIFF
--- a/shopping-cart/shopping-cart-java/shopping-cart/src/test/java/com/example/shoppingcart/impl/ShoppingCartTest.java
+++ b/shopping-cart/shopping-cart-java/shopping-cart/src/test/java/com/example/shoppingcart/impl/ShoppingCartTest.java
@@ -1,11 +1,13 @@
 package com.example.shoppingcart.impl;
 
+import akka.actor.testkit.typed.javadsl.LogCapturing;
 import akka.actor.testkit.typed.javadsl.TestKitJunitResource;
 import akka.actor.testkit.typed.javadsl.TestProbe;
 import akka.actor.typed.ActorRef;
 import akka.persistence.typed.PersistenceId;
 import org.junit.Assert;
 import org.junit.ClassRule;
+import org.junit.Rule;
 import org.junit.Test;
 
 import java.util.UUID;
@@ -25,6 +27,9 @@ public class ShoppingCartTest {
 
     @ClassRule
     public static final TestKitJunitResource testKit = new TestKitJunitResource(config);
+
+    @Rule
+    public final LogCapturing logCapturing = new LogCapturing();
 
     private String randomId() {
         return UUID.randomUUID().toString();

--- a/shopping-cart/shopping-cart-java/shopping-cart/src/test/resources/logback.xml
+++ b/shopping-cart/shopping-cart-java/shopping-cart/src/test/resources/logback.xml
@@ -7,6 +7,12 @@
         </encoder>
     </appender>
 
+    <appender name="CapturingAppender" class="akka.actor.testkit.typed.internal.CapturingAppender" />
+
+    <logger name="akka.actor.testkit.typed.internal.CapturingAppenderDelegate" >
+        <appender-ref ref="STDOUT"/>
+    </logger>
+
     <logger name="org.apache.cassandra" level="ERROR" />
     <logger name="com.datastax.driver" level="WARN" />
 
@@ -14,6 +20,7 @@
 
     <root level="INFO">
         <appender-ref ref="STDOUT" />
+        <appender-ref ref="CapturingAppender"/>
     </root>
 
 </configuration>


### PR DESCRIPTION
This reverts commit ce2541886c28a08e328a7211453363deed28ac13.

Fixes #122

Looks at a run on Travis CI, the `java.lang.IllegalStateException: CapturingAppender not defined for [ROOT]` is no longer being triggered.  I presume this was fixed either by Akka RC2 or maybe fixing something in the dependencies resolved?  Either way, this is no longer an issue.