### PR TITLE
Demonstrates usage of DevMode Service Registry portName

### DIFF
--- a/grpc-example/grpc-example-scala/build.sbt
+++ b/grpc-example/grpc-example-scala/build.sbt
@@ -19,7 +19,8 @@ val `hello-impl-HTTPS-port` = 11000
 def workaroundSettings: Seq[sbt.Setting[_]] = Seq(
   // Lagom still can't register a service under the gRPC name so we hard-code 
   // the port and use the value to add the entry on the Service Registry
-  lagomServiceHttpsPort := `hello-impl-HTTPS-port`
+  lagomServiceHttpsPort := `hello-impl-HTTPS-port`,
+  lagomServiceAddress := "localhost"
 )
 
 lazy val `lagom-scala-grpc-example` = (project in file("."))
@@ -82,13 +83,6 @@ lazy val `hello-proxy-impl` = (project in file("hello-proxy-impl"))
 // to make the devMode startup faster.
 lagomCassandraEnabled in ThisBuild := false
 lagomKafkaEnabled in ThisBuild := false
-
-
-// This adds an entry on the LagomDevMode Service Registry. With this information on
-// the Service Registry a client using Service Discovery to Lookup("helloworld.GreeterService")
-// will get "https://localhost:11000" and then be able to send a request.
-// See declaration and usages of `hello-impl-HTTPS-port`.
-lagomUnmanagedServices in ThisBuild := Map("helloworld.GreeterService" -> s"https://localhost:${`hello-impl-HTTPS-port`}")
 
 //----------------------------------
 

--- a/grpc-example/grpc-example-scala/hello-proxy-impl/src/main/scala/com/example/helloproxy/impl/HelloProxyLoader.scala
+++ b/grpc-example/grpc-example-scala/hello-proxy-impl/src/main/scala/com/example/helloproxy/impl/HelloProxyLoader.scala
@@ -38,7 +38,7 @@ abstract class HelloProxyApplication(context: LagomApplicationContext)
   private implicit val sys: ActorSystem = actorSystem
 
   private lazy val settings = GrpcClientSettings
-    .usingServiceDiscovery(GreeterService.name)
+    .usingServiceDiscovery("hello-srvc")
     .withServicePortName("https")
     .withDeadline(Duration.create(5, TimeUnit.SECONDS)) // response timeout
     .withConnectionAttempts(5) // use a small reconnectionAttempts value to cause a client reload in case of failure


### PR DESCRIPTION
NOT FOR MERGE

This PR makes the minimal changes on `grpc-example-scala` so everything runs without relying on `unmanagedServices` in Lagom's DevMode. There are two steps required:

1. the target service must bind to the `localhost` address (instead of the default `127.0.0.1` to pass al SSL Certificate validations)
2. the gRPC client must lookup the `"hello-srvc"` name. This operation may fail but eventually succeeds. The reason is that the internal `Channel` may be built before the `hello-srvc` is available in which case build fails. The `Channel` creation is eventually retried.


PS: I've done this on `1.5.x` because `1.6.x` is affected by https://github.com/akka/akka-grpc/issues/731.