### PR TITLE
gRPC Java example: use Akka HTTP 10.1.13

### DIFF
--- a/grpc-example/grpc-example-java/hello-impl/pom.xml
+++ b/grpc-example/grpc-example-java/hello-impl/pom.xml
@@ -64,6 +64,26 @@
             <artifactId>akka-http2-support_${scala.binary.version}</artifactId>
             <version>${akka.http.version}</version>
         </dependency>
+        <dependency>
+            <groupId>com.typesafe.akka</groupId>
+            <artifactId>akka-http-core_${scala.binary.version}</artifactId>
+            <version>${akka.http.version}</version>
+        </dependency>
+        <dependency>
+            <groupId>com.typesafe.akka</groupId>
+            <artifactId>akka-http_${scala.binary.version}</artifactId>
+            <version>${akka.http.version}</version>
+        </dependency>
+        <dependency>
+            <groupId>com.typesafe.akka</groupId>
+            <artifactId>akka-parsing_${scala.binary.version}</artifactId>
+            <version>${akka.http.version}</version>
+        </dependency>
+        <dependency>
+            <groupId>com.typesafe.akka</groupId>
+            <artifactId>akka-http-spray-json_${scala.binary.version}</artifactId>
+            <version>${akka.http.version}</version>
+        </dependency>
 
     </dependencies>
 

--- a/grpc-example/grpc-example-java/hello-proxy-impl/pom.xml
+++ b/grpc-example/grpc-example-java/hello-proxy-impl/pom.xml
@@ -59,6 +59,26 @@
             <artifactId>akka-http2-support_${scala.binary.version}</artifactId>
             <version>${akka.http.version}</version>
         </dependency>
+        <dependency>
+            <groupId>com.typesafe.akka</groupId>
+            <artifactId>akka-http-core_${scala.binary.version}</artifactId>
+            <version>${akka.http.version}</version>
+        </dependency>
+        <dependency>
+            <groupId>com.typesafe.akka</groupId>
+            <artifactId>akka-http_${scala.binary.version}</artifactId>
+            <version>${akka.http.version}</version>
+        </dependency>
+        <dependency>
+            <groupId>com.typesafe.akka</groupId>
+            <artifactId>akka-parsing_${scala.binary.version}</artifactId>
+            <version>${akka.http.version}</version>
+        </dependency>
+        <dependency>
+            <groupId>com.typesafe.akka</groupId>
+            <artifactId>akka-http-spray-json_${scala.binary.version}</artifactId>
+            <version>${akka.http.version}</version>
+        </dependency>
 
     </dependencies>
 

--- a/grpc-example/grpc-example-java/pom.xml
+++ b/grpc-example/grpc-example-java/pom.xml
@@ -78,7 +78,7 @@
         <scala.binary.version>2.12</scala.binary.version>
         <lagom.version>1.6.4</lagom.version>
         <play.version>2.8.1</play.version>
-        <akka.http.version>10.1.12</akka.http.version>
+        <akka.http.version>10.1.13</akka.http.version>
         <akka.grpc.version>1.0.2</akka.grpc.version>
         <play.grpc.version>0.9.1</play.grpc.version>
 


### PR DESCRIPTION
This shows the dependencies that need to be listed explicitly to use Akka HTTP 10.1.13 in the gRPC Java example.