### PR TITLE
Demonstrate a basic test based on EventSourcedBehaviorTestKit

### DIFF
--- a/shopping-cart/shopping-cart-scala/build.sbt
+++ b/shopping-cart/shopping-cart-scala/build.sbt
@@ -50,7 +50,8 @@ lazy val `shopping-cart` = (project in file("shopping-cart"))
       scalaTest,
       postgresDriver,
       lagomScaladslAkkaDiscovery,
-      akkaDiscoveryKubernetesApi
+      akkaDiscoveryKubernetesApi,
+      "com.typesafe.akka" %% "akka-persistence-testkit" % "2.6.8" % Test
     )
   )
   .settings(dockerSettings)

--- a/shopping-cart/shopping-cart-scala/shopping-cart/src/test/scala/com/example/shoppingcart/impl/ShoppingCartEntitySpec.scala
+++ b/shopping-cart/shopping-cart-scala/shopping-cart/src/test/scala/com/example/shoppingcart/impl/ShoppingCartEntitySpec.scala
@@ -2,191 +2,72 @@ package com.example.shoppingcart.impl
 
 import java.util.UUID
 
-import akka.actor.testkit.typed.scaladsl.LogCapturing
+import akka.actor.ActorSystem
+import akka.actor.BootstrapSetup
+import akka.actor.setup.ActorSystemSetup
 import akka.actor.testkit.typed.scaladsl.ScalaTestWithActorTestKit
+import akka.actor.typed
+import akka.persistence.testkit.scaladsl.EventSourcedBehaviorTestKit
 import akka.persistence.typed.PersistenceId
+import com.example.shoppingcart.impl.ShoppingCart.AddItem
+import com.example.shoppingcart.impl.ShoppingCart.Confirmation
+import com.lightbend.lagom.scaladsl.playjson.JsonSerializerRegistry
+import com.typesafe.config.Config
+import com.typesafe.config.ConfigFactory
 import org.scalatest.wordspec.AnyWordSpecLike
 
+object  ShoppingCartEntitySpec {
+  val testConfig =   ConfigFactory.parseString(
+    """
+      |
+      |akka.actor {
+      |  serialization-bindings {
+      |    # Commands won't use play-json but Akka's jackson support.
+      |    # See https://doc.akka.io/docs/akka/2.6/serialization-jackson.html
+      |    "com.example.shoppingcart.impl.ShoppingCart$CommandSerializable" = jackson-json
+      |  }
+      |}
+      |
+      |akka.actor {
+      |  serialization-identifiers {
+      |    "com.lightbend.lagom.scaladsl.playjson.PlayJsonSerializer" = 1000004
+      |  }
+      |}
+      |
+      |""".stripMargin)
+
+  private def typedActorSystem(name: String, config: Config): typed.ActorSystem[Nothing] = {
+
+    val setup: ActorSystemSetup =
+      ActorSystemSetup(
+        BootstrapSetup(classLoader = Some(classOf[ShoppingCartEntitySpec].getClassLoader), config = Some(config), None),
+        JsonSerializerRegistry.serializationSetupFor(ShoppingCartSerializerRegistry)
+      )
+    import akka.actor.typed.scaladsl.adapter._
+    ActorSystem(name, setup).toTyped
+  }
+
+}
+
 class ShoppingCartEntitySpec
-    extends ScalaTestWithActorTestKit(s"""
-                                         |akka.persistence.journal.plugin = "akka.persistence.journal.inmem"
-                                         |akka.persistence.snapshot-store.plugin = "akka.persistence.snapshot-store.local"
-                                         |akka.persistence.snapshot-store.local.dir = "target/snapshot-${UUID
-      .randomUUID()
-      .toString}"
-                                         |""".stripMargin)
-    with AnyWordSpecLike
-    with LogCapturing {
+  extends ScalaTestWithActorTestKit(
+    ShoppingCartEntitySpec.typedActorSystem("ShoppingCartEntitySpec",
+      EventSourcedBehaviorTestKit.config.withFallback(ShoppingCartEntitySpec.testConfig)
+    )
+  )
+    with AnyWordSpecLike {
 
   private def randomId(): String = UUID.randomUUID().toString
 
   "ShoppingCart" must {
     "add an item" in {
-      val probe        = createTestProbe[ShoppingCart.Confirmation]()
-      val shoppingCart = spawn(ShoppingCart(PersistenceId("ShoppingCart", randomId())))
-      shoppingCart ! ShoppingCart.AddItem(UUID.randomUUID().toString, 2, probe.ref)
+      val entity = EventSourcedBehaviorTestKit[ShoppingCart.Command, ShoppingCart.Event, ShoppingCart](
+        system,
+        ShoppingCart(PersistenceId("ShoppingCart", randomId()))
+      )
 
-      probe.expectMessageType[ShoppingCart.Accepted]
-    }
-
-    "remove an item" in {
-      val probe        = createTestProbe[ShoppingCart.Confirmation]()
-      val shoppingCart = spawn(ShoppingCart(PersistenceId("ShoppingCart", randomId())))
-
-      // First add a item
-      val itemId = randomId()
-      shoppingCart ! ShoppingCart.AddItem(itemId, 2, probe.ref)
-      probe.expectMessageType[ShoppingCart.Accepted]
-
-      // Then remove the item
-      shoppingCart ! ShoppingCart.RemoveItem(itemId, probe.ref)
-      probe.receiveMessage() match {
-        case ShoppingCart.Accepted(summary) => summary.items.contains(itemId) shouldBe false
-        case ShoppingCart.Rejected(reason)  => fail(s"Message was rejected with reason: $reason")
-      }
-    }
-
-    "update item quantity" in {
-      val probe        = createTestProbe[ShoppingCart.Confirmation]()
-      val shoppingCart = spawn(ShoppingCart(PersistenceId("ShoppingCart", randomId())))
-
-      // First add a item
-      val itemId = randomId()
-      shoppingCart ! ShoppingCart.AddItem(itemId, 2, probe.ref)
-      probe.expectMessageType[ShoppingCart.Accepted]
-
-      // Update item quantity
-      shoppingCart ! ShoppingCart.AdjustItemQuantity(itemId, 5, probe.ref)
-      probe.receiveMessage() match {
-        case ShoppingCart.Accepted(summary) => summary.items.get(itemId) shouldBe Some(5)
-        case ShoppingCart.Rejected(reason)  => fail(s"Message was rejected with reason: $reason")
-      }
-    }
-
-    "allow checking out" in {
-      val probe        = createTestProbe[ShoppingCart.Confirmation]()
-      val shoppingCart = spawn(ShoppingCart(PersistenceId("ShoppingCart", randomId())))
-
-      // First add a item
-      shoppingCart ! ShoppingCart.AddItem(randomId(), 2, probe.ref)
-      probe.expectMessageType[ShoppingCart.Accepted]
-
-      // Checkout shopping cart
-      shoppingCart ! ShoppingCart.Checkout(probe.ref)
-      probe.receiveMessage() match {
-        case ShoppingCart.Accepted(summary) => summary.checkedOut shouldBe true
-        case ShoppingCart.Rejected(reason)  => fail(s"Message was rejected with reason: $reason")
-      }
-    }
-
-    "allow getting shopping cart summary" in {
-      val probeAdd     = createTestProbe[ShoppingCart.Confirmation]()
-      val shoppingCart = spawn(ShoppingCart(PersistenceId("ShoppingCart", randomId())))
-
-      // First add a item
-      val itemId = randomId()
-      shoppingCart ! ShoppingCart.AddItem(itemId, 2, probeAdd.ref)
-
-      // Get the summary
-      // Use another probe since ShoppingCart.Get does not return a ShoppingCart.Confirmation
-      val probeGet = createTestProbe[ShoppingCart.Summary]()
-      shoppingCart ! ShoppingCart.Get(probeGet.ref)
-      probeGet.receiveMessage().items.get(itemId) shouldBe Some(2)
-    }
-
-    "fail when removing an item that isn't added" in {
-      val probe        = createTestProbe[ShoppingCart.Confirmation]()
-      val shoppingCart = spawn(ShoppingCart(PersistenceId("ShoppingCart", randomId())))
-
-      // First add a item
-      val itemId = randomId()
-      shoppingCart ! ShoppingCart.AddItem(itemId, 2, probe.ref)
-      probe.expectMessageType[ShoppingCart.Accepted]
-
-      // Removing is idempotent, so command will not be Rejected
-      val toRemoveItemId = randomId()
-      shoppingCart ! ShoppingCart.RemoveItem(toRemoveItemId, probe.ref)
-      probe.receiveMessage() match {
-        case ShoppingCart.Accepted(summary) => summary.items.get(itemId) shouldBe Some(2)
-        case ShoppingCart.Rejected(reason)  => fail(s"Message was rejected with reason: $reason")
-      }
-    }
-
-    "fail when adding a negative number of items" in {
-      val probe        = createTestProbe[ShoppingCart.Confirmation]()
-      val shoppingCart = spawn(ShoppingCart(PersistenceId("ShoppingCart", randomId())))
-
-      val quantity = -2
-      shoppingCart ! ShoppingCart.AddItem(randomId(), quantity, probe.ref)
-      probe.expectMessage(ShoppingCart.Rejected("Quantity must be greater than zero"))
-    }
-
-    "fail when adjusting item quantity to negative number" in {
-      val probe        = createTestProbe[ShoppingCart.Confirmation]()
-      val shoppingCart = spawn(ShoppingCart(PersistenceId("ShoppingCart", randomId())))
-
-      // First add a item so it is possible to checkout
-      val itemId = randomId()
-      shoppingCart ! ShoppingCart.AddItem(itemId, 2, probe.ref)
-      probe.expectMessageType[ShoppingCart.Accepted]
-
-      val quantity = -2
-      shoppingCart ! ShoppingCart.AdjustItemQuantity(itemId, quantity, probe.ref)
-      probe.expectMessage(ShoppingCart.Rejected("Quantity must be greater than zero"))
-    }
-
-    "fail when adjusting quantity for an item that isn't added" in {
-      val probe        = createTestProbe[ShoppingCart.Confirmation]()
-      val shoppingCart = spawn(ShoppingCart(PersistenceId("ShoppingCart", randomId())))
-
-      val itemId = randomId()
-      shoppingCart ! ShoppingCart.AdjustItemQuantity(itemId, 2, probe.ref)
-      probe.expectMessage(ShoppingCart.Rejected(s"Cannot adjust quantity for item '$itemId'. Item not present on cart"))
-    }
-
-    "fail when adding an item to a checked out cart" in {
-      val probe        = createTestProbe[ShoppingCart.Confirmation]()
-      val shoppingCart = spawn(ShoppingCart(PersistenceId("ShoppingCart", randomId())))
-
-      // First add a item so it is possible to checkout
-      val itemId = randomId()
-      shoppingCart ! ShoppingCart.AddItem(itemId, 2, probe.ref)
-      probe.expectMessageType[ShoppingCart.Accepted]
-
-      // Then checkout the shopping cart
-      shoppingCart ! ShoppingCart.Checkout(probe.ref)
-      probe.expectMessageType[ShoppingCart.Accepted]
-
-      // Then fail when adding new items
-      shoppingCart ! ShoppingCart.AddItem(randomId(), 2, probe.ref)
-      probe.expectMessage(ShoppingCart.Rejected("Cannot add an item to a checked-out cart"))
-    }
-
-    "fail when checking out twice" in {
-      val probe        = createTestProbe[ShoppingCart.Confirmation]()
-      val shoppingCart = spawn(ShoppingCart(PersistenceId("ShoppingCart", randomId())))
-
-      // First add a item so it is possible to checkout
-      val itemId = randomId()
-      shoppingCart ! ShoppingCart.AddItem(itemId, 2, probe.ref)
-      probe.expectMessageType[ShoppingCart.Accepted]
-
-      // Then checkout the shopping cart
-      shoppingCart ! ShoppingCart.Checkout(probe.ref)
-      probe.expectMessageType[ShoppingCart.Accepted]
-
-      // Then fail to checkout again
-      shoppingCart ! ShoppingCart.Checkout(probe.ref)
-      probe.expectMessage(ShoppingCart.Rejected("Cannot checkout a checked-out cart"))
-    }
-
-    "fail when checking out an empty cart" in {
-      val probe        = createTestProbe[ShoppingCart.Confirmation]()
-      val shoppingCart = spawn(ShoppingCart(PersistenceId("ShoppingCart", randomId())))
-
-      // Fail to checkout empty shopping cart
-      shoppingCart ! ShoppingCart.Checkout(probe.ref)
-      probe.expectMessage(ShoppingCart.Rejected("Cannot checkout an empty shopping cart"))
+      val result = entity.runCommand(AddItem("1", 1, _))
+      result.reply shouldBe a[Confirmation]
     }
   }
 }

--- a/shopping-cart/shopping-cart-scala/shopping-cart/src/test/scala/com/example/shoppingcart/impl/ShoppingCartEntitySpec.scala
+++ b/shopping-cart/shopping-cart-scala/shopping-cart/src/test/scala/com/example/shoppingcart/impl/ShoppingCartEntitySpec.scala
@@ -2,81 +2,191 @@ package com.example.shoppingcart.impl
 
 import java.util.UUID
 
-import akka.actor.ActorSystem
-import akka.actor.BootstrapSetup
-import akka.actor.setup.ActorSystemSetup
+import akka.actor.testkit.typed.scaladsl.LogCapturing
 import akka.actor.testkit.typed.scaladsl.ScalaTestWithActorTestKit
-import akka.actor.typed
-import akka.persistence.testkit.scaladsl.EventSourcedBehaviorTestKit
 import akka.persistence.typed.PersistenceId
-import com.example.shoppingcart.impl.ShoppingCart.AddItem
-import com.example.shoppingcart.impl.ShoppingCart.Confirmation
-import com.lightbend.lagom.scaladsl.playjson.JsonSerializerRegistry
-import com.typesafe.config.Config
-import com.typesafe.config.ConfigFactory
 import org.scalatest.wordspec.AnyWordSpecLike
 
-
-/**
- * ConfigFactory.load will read the serialization settings from application.conf
- */
 class ShoppingCartEntitySpec
-  extends AbstractShoppingCartEntitySpec(
-    EventSourcedBehaviorTestKit.config.withFallback(ConfigFactory.load)
-  )
-
-/**
- * CustomConfigShoppingCartEntitySpec demonstrates an alternative to ShoppingCartEntitySpec that
- * uses custom configuration instead of relying on `ConfigFactory.load`
- */
-object CustomConfigShoppingCartEntitySpec {
-  val testConfig =
-    ConfigFactory.parseString("""
-                                |akka.actor {
-                                |  serialization-bindings {
-                                |    "com.example.shoppingcart.impl.ShoppingCart$CommandSerializable" = jackson-json
-                                |  }
-                                |}
-                                |""".stripMargin)
-}
-
-class CustomConfigShoppingCartEntitySpec
-  extends AbstractShoppingCartEntitySpec(
-    EventSourcedBehaviorTestKit.config.withFallback(CustomConfigShoppingCartEntitySpec.testConfig)
-  )
-
-object AbstractShoppingCartEntitySpec {
-  private val userSerializationRegistry = ShoppingCartSerializerRegistry
-  // This method is unexpected complexity in order to build a typed ActorSystem with
-  // the user's `ShoppingCartSerializerRegistry` registered so that user messages can
-  // still use Lagom's play-json serializers with Akka Persistence Typed.
-  def typedActorSystem(name: String, config: Config): typed.ActorSystem[Nothing] = {
-    val setup: ActorSystemSetup =
-      ActorSystemSetup(
-        BootstrapSetup(classLoader = Some(classOf[AbstractShoppingCartEntitySpec].getClassLoader), config = Some(config), None),
-        JsonSerializerRegistry.serializationSetupFor(userSerializationRegistry)
-      )
-    import akka.actor.typed.scaladsl.adapter._
-    ActorSystem(name, setup).toTyped
-  }
-
-}
-
-abstract class AbstractShoppingCartEntitySpec(config: Config)
-    extends ScalaTestWithActorTestKit(AbstractShoppingCartEntitySpec.typedActorSystem("ShoppingCartEntitySpec", config))
-    with AnyWordSpecLike {
+  extends ScalaTestWithActorTestKit(s"""
+                                       |akka.persistence.journal.plugin = "akka.persistence.journal.inmem"
+                                       |akka.persistence.snapshot-store.plugin = "akka.persistence.snapshot-store.local"
+                                       |akka.persistence.snapshot-store.local.dir = "target/snapshot-${UUID
+    .randomUUID()
+    .toString}"
+                                       |""".stripMargin)
+    with AnyWordSpecLike
+    with LogCapturing {
 
   private def randomId(): String = UUID.randomUUID().toString
 
   "ShoppingCart" must {
     "add an item" in {
-      val entity = EventSourcedBehaviorTestKit[ShoppingCart.Command, ShoppingCart.Event, ShoppingCart](
-        system,
-        ShoppingCart(PersistenceId("ShoppingCart", randomId()))
-      )
+      val probe        = createTestProbe[ShoppingCart.Confirmation]()
+      val shoppingCart = spawn(ShoppingCart(PersistenceId("ShoppingCart", randomId())))
+      shoppingCart ! ShoppingCart.AddItem(UUID.randomUUID().toString, 2, probe.ref)
 
-      val result = entity.runCommand(AddItem("1", 1, _))
-      result.reply shouldBe a[Confirmation]
+      probe.expectMessageType[ShoppingCart.Accepted]
+    }
+
+    "remove an item" in {
+      val probe        = createTestProbe[ShoppingCart.Confirmation]()
+      val shoppingCart = spawn(ShoppingCart(PersistenceId("ShoppingCart", randomId())))
+
+      // First add a item
+      val itemId = randomId()
+      shoppingCart ! ShoppingCart.AddItem(itemId, 2, probe.ref)
+      probe.expectMessageType[ShoppingCart.Accepted]
+
+      // Then remove the item
+      shoppingCart ! ShoppingCart.RemoveItem(itemId, probe.ref)
+      probe.receiveMessage() match {
+        case ShoppingCart.Accepted(summary) => summary.items.contains(itemId) shouldBe false
+        case ShoppingCart.Rejected(reason)  => fail(s"Message was rejected with reason: $reason")
+      }
+    }
+
+    "update item quantity" in {
+      val probe        = createTestProbe[ShoppingCart.Confirmation]()
+      val shoppingCart = spawn(ShoppingCart(PersistenceId("ShoppingCart", randomId())))
+
+      // First add a item
+      val itemId = randomId()
+      shoppingCart ! ShoppingCart.AddItem(itemId, 2, probe.ref)
+      probe.expectMessageType[ShoppingCart.Accepted]
+
+      // Update item quantity
+      shoppingCart ! ShoppingCart.AdjustItemQuantity(itemId, 5, probe.ref)
+      probe.receiveMessage() match {
+        case ShoppingCart.Accepted(summary) => summary.items.get(itemId) shouldBe Some(5)
+        case ShoppingCart.Rejected(reason)  => fail(s"Message was rejected with reason: $reason")
+      }
+    }
+
+    "allow checking out" in {
+      val probe        = createTestProbe[ShoppingCart.Confirmation]()
+      val shoppingCart = spawn(ShoppingCart(PersistenceId("ShoppingCart", randomId())))
+
+      // First add a item
+      shoppingCart ! ShoppingCart.AddItem(randomId(), 2, probe.ref)
+      probe.expectMessageType[ShoppingCart.Accepted]
+
+      // Checkout shopping cart
+      shoppingCart ! ShoppingCart.Checkout(probe.ref)
+      probe.receiveMessage() match {
+        case ShoppingCart.Accepted(summary) => summary.checkedOut shouldBe true
+        case ShoppingCart.Rejected(reason)  => fail(s"Message was rejected with reason: $reason")
+      }
+    }
+
+    "allow getting shopping cart summary" in {
+      val probeAdd     = createTestProbe[ShoppingCart.Confirmation]()
+      val shoppingCart = spawn(ShoppingCart(PersistenceId("ShoppingCart", randomId())))
+
+      // First add a item
+      val itemId = randomId()
+      shoppingCart ! ShoppingCart.AddItem(itemId, 2, probeAdd.ref)
+
+      // Get the summary
+      // Use another probe since ShoppingCart.Get does not return a ShoppingCart.Confirmation
+      val probeGet = createTestProbe[ShoppingCart.Summary]()
+      shoppingCart ! ShoppingCart.Get(probeGet.ref)
+      probeGet.receiveMessage().items.get(itemId) shouldBe Some(2)
+    }
+
+    "fail when removing an item that isn't added" in {
+      val probe        = createTestProbe[ShoppingCart.Confirmation]()
+      val shoppingCart = spawn(ShoppingCart(PersistenceId("ShoppingCart", randomId())))
+
+      // First add a item
+      val itemId = randomId()
+      shoppingCart ! ShoppingCart.AddItem(itemId, 2, probe.ref)
+      probe.expectMessageType[ShoppingCart.Accepted]
+
+      // Removing is idempotent, so command will not be Rejected
+      val toRemoveItemId = randomId()
+      shoppingCart ! ShoppingCart.RemoveItem(toRemoveItemId, probe.ref)
+      probe.receiveMessage() match {
+        case ShoppingCart.Accepted(summary) => summary.items.get(itemId) shouldBe Some(2)
+        case ShoppingCart.Rejected(reason)  => fail(s"Message was rejected with reason: $reason")
+      }
+    }
+
+    "fail when adding a negative number of items" in {
+      val probe        = createTestProbe[ShoppingCart.Confirmation]()
+      val shoppingCart = spawn(ShoppingCart(PersistenceId("ShoppingCart", randomId())))
+
+      val quantity = -2
+      shoppingCart ! ShoppingCart.AddItem(randomId(), quantity, probe.ref)
+      probe.expectMessage(ShoppingCart.Rejected("Quantity must be greater than zero"))
+    }
+
+    "fail when adjusting item quantity to negative number" in {
+      val probe        = createTestProbe[ShoppingCart.Confirmation]()
+      val shoppingCart = spawn(ShoppingCart(PersistenceId("ShoppingCart", randomId())))
+
+      // First add a item so it is possible to checkout
+      val itemId = randomId()
+      shoppingCart ! ShoppingCart.AddItem(itemId, 2, probe.ref)
+      probe.expectMessageType[ShoppingCart.Accepted]
+
+      val quantity = -2
+      shoppingCart ! ShoppingCart.AdjustItemQuantity(itemId, quantity, probe.ref)
+      probe.expectMessage(ShoppingCart.Rejected("Quantity must be greater than zero"))
+    }
+
+    "fail when adjusting quantity for an item that isn't added" in {
+      val probe        = createTestProbe[ShoppingCart.Confirmation]()
+      val shoppingCart = spawn(ShoppingCart(PersistenceId("ShoppingCart", randomId())))
+
+      val itemId = randomId()
+      shoppingCart ! ShoppingCart.AdjustItemQuantity(itemId, 2, probe.ref)
+      probe.expectMessage(ShoppingCart.Rejected(s"Cannot adjust quantity for item '$itemId'. Item not present on cart"))
+    }
+
+    "fail when adding an item to a checked out cart" in {
+      val probe        = createTestProbe[ShoppingCart.Confirmation]()
+      val shoppingCart = spawn(ShoppingCart(PersistenceId("ShoppingCart", randomId())))
+
+      // First add a item so it is possible to checkout
+      val itemId = randomId()
+      shoppingCart ! ShoppingCart.AddItem(itemId, 2, probe.ref)
+      probe.expectMessageType[ShoppingCart.Accepted]
+
+      // Then checkout the shopping cart
+      shoppingCart ! ShoppingCart.Checkout(probe.ref)
+      probe.expectMessageType[ShoppingCart.Accepted]
+
+      // Then fail when adding new items
+      shoppingCart ! ShoppingCart.AddItem(randomId(), 2, probe.ref)
+      probe.expectMessage(ShoppingCart.Rejected("Cannot add an item to a checked-out cart"))
+    }
+
+    "fail when checking out twice" in {
+      val probe        = createTestProbe[ShoppingCart.Confirmation]()
+      val shoppingCart = spawn(ShoppingCart(PersistenceId("ShoppingCart", randomId())))
+
+      // First add a item so it is possible to checkout
+      val itemId = randomId()
+      shoppingCart ! ShoppingCart.AddItem(itemId, 2, probe.ref)
+      probe.expectMessageType[ShoppingCart.Accepted]
+
+      // Then checkout the shopping cart
+      shoppingCart ! ShoppingCart.Checkout(probe.ref)
+      probe.expectMessageType[ShoppingCart.Accepted]
+
+      // Then fail to checkout again
+      shoppingCart ! ShoppingCart.Checkout(probe.ref)
+      probe.expectMessage(ShoppingCart.Rejected("Cannot checkout a checked-out cart"))
+    }
+
+    "fail when checking out an empty cart" in {
+      val probe        = createTestProbe[ShoppingCart.Confirmation]()
+      val shoppingCart = spawn(ShoppingCart(PersistenceId("ShoppingCart", randomId())))
+
+      // Fail to checkout empty shopping cart
+      shoppingCart ! ShoppingCart.Checkout(probe.ref)
+      probe.expectMessage(ShoppingCart.Rejected("Cannot checkout an empty shopping cart"))
     }
   }
 }

--- a/shopping-cart/shopping-cart-scala/shopping-cart/src/test/scala/com/example/shoppingcart/impl/ShoppingCartEntityTypedTestkitSpec.scala
+++ b/shopping-cart/shopping-cart-scala/shopping-cart/src/test/scala/com/example/shoppingcart/impl/ShoppingCartEntityTypedTestkitSpec.scala
@@ -1,0 +1,82 @@
+package com.example.shoppingcart.impl
+
+import java.util.UUID
+
+import akka.actor.ActorSystem
+import akka.actor.BootstrapSetup
+import akka.actor.setup.ActorSystemSetup
+import akka.actor.testkit.typed.scaladsl.ScalaTestWithActorTestKit
+import akka.actor.typed
+import akka.persistence.testkit.scaladsl.EventSourcedBehaviorTestKit
+import akka.persistence.typed.PersistenceId
+import com.example.shoppingcart.impl.ShoppingCart.AddItem
+import com.example.shoppingcart.impl.ShoppingCart.Confirmation
+import com.lightbend.lagom.scaladsl.playjson.JsonSerializerRegistry
+import com.typesafe.config.Config
+import com.typesafe.config.ConfigFactory
+import org.scalatest.wordspec.AnyWordSpecLike
+
+
+/**
+ * ConfigFactory.load will read the serialization settings from application.conf
+ */
+class ShoppingCartEntityTypedTestkitSpec
+  extends AbstractShoppingCartEntityTypedTestkitSpec(
+    EventSourcedBehaviorTestKit.config.withFallback(ConfigFactory.load)
+  )
+
+/**
+ * CustomConfigShoppingCartEntityTypedTestkitSpec demonstrates an alternative to ShoppingCartEntityTypedTestkitSpec that
+ * uses custom configuration instead of relying on `ConfigFactory.load`
+ */
+object CustomConfigShoppingCartEntityTypedTestkitSpec {
+  val testConfig =
+    ConfigFactory.parseString("""
+                                |akka.actor {
+                                |  serialization-bindings {
+                                |    "com.example.shoppingcart.impl.ShoppingCart$CommandSerializable" = jackson-json
+                                |  }
+                                |}
+                                |""".stripMargin)
+}
+
+class CustomConfigShoppingCartEntityTypedTestkitSpec
+  extends AbstractShoppingCartEntityTypedTestkitSpec(
+    EventSourcedBehaviorTestKit.config.withFallback(CustomConfigShoppingCartEntityTypedTestkitSpec.testConfig)
+  )
+
+object AbstractShoppingCartEntityTypedTestkitSpec {
+  private val userSerializationRegistry = ShoppingCartSerializerRegistry
+  // This method is unexpected complexity in order to build a typed ActorSystem with
+  // the user's `ShoppingCartSerializerRegistry` registered so that user messages can
+  // still use Lagom's play-json serializers with Akka Persistence Typed.
+  def typedActorSystem(name: String, config: Config): typed.ActorSystem[Nothing] = {
+    val setup: ActorSystemSetup =
+      ActorSystemSetup(
+        BootstrapSetup(classLoader = Some(classOf[AbstractShoppingCartEntityTypedTestkitSpec].getClassLoader), config = Some(config), None),
+        JsonSerializerRegistry.serializationSetupFor(userSerializationRegistry)
+      )
+    import akka.actor.typed.scaladsl.adapter._
+    ActorSystem(name, setup).toTyped
+  }
+
+}
+
+abstract class AbstractShoppingCartEntityTypedTestkitSpec(config: Config)
+    extends ScalaTestWithActorTestKit(AbstractShoppingCartEntityTypedTestkitSpec.typedActorSystem("ShoppingCartEntityTypedTestkitSpec", config))
+    with AnyWordSpecLike {
+
+  private def randomId(): String = UUID.randomUUID().toString
+
+  "ShoppingCart" must {
+    "add an item" in {
+      val entity = EventSourcedBehaviorTestKit[ShoppingCart.Command, ShoppingCart.Event, ShoppingCart](
+        system,
+        ShoppingCart(PersistenceId("ShoppingCart", randomId()))
+      )
+
+      val result = entity.runCommand(AddItem("1", 1, _))
+      result.reply shouldBe a[Confirmation]
+    }
+  }
+}


### PR DESCRIPTION
refs #197 

Demonstrates how to scaffold a test for an Akka Persistence Typed entity using Lagom Play JSON serializers, Akka Jackson serializers and the Akka Persistence Typed testkit `EventSroucedBehaviorTeskit`.