### PR TITLE
Use default Kafka port

### DIFF
--- a/shopping-cart/shopping-cart-java/pom.xml
+++ b/shopping-cart/shopping-cart-java/pom.xml
@@ -64,7 +64,6 @@
                 <version>${lagom.version}</version>
                 <configuration>
                     <cassandraEnabled>false</cassandraEnabled>
-                    <kafkaPort>10000</kafkaPort>
                     <kafkaEnabled>false</kafkaEnabled>
                 </configuration>
             </plugin>


### PR DESCRIPTION
This sample now uses external Kafka on dev mode. The external kafka is run on docker-compose on the default port.